### PR TITLE
use default staff None for Directions (instead of 1)

### DIFF
--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -569,7 +569,7 @@ def _handle_direction(e, position, part, ongoing):
     #     %direction;
     # >
 
-    staff = get_value_from_tag(e, 'staff', int) or 1
+    staff = get_value_from_tag(e, 'staff', int) or None
 
     if get_value_from_attribute(e, 'sound/fine', str) == 'yes':
         part.add(score.Fine(), position)


### PR DESCRIPTION
This way the default staff for Direction objects is consistent with
default staff values for other objects.

This PR fixes https://github.com/CPJKU/partitura/issues/12