### PR TITLE
Fix issue #31

### DIFF
--- a/partitura/io/exportmidi.py
+++ b/partitura/io/exportmidi.py
@@ -7,7 +7,7 @@ from collections import defaultdict, OrderedDict
 from mido import MidiFile, MidiTrack, Message, MetaMessage
 
 import partitura.score as score
-from partitura.utils import partition, INT_TYPE, FLOAT_TYPE
+from partitura.utils import partition
 
 __all__ = ["save_score_midi", "save_performance_midi"]
 
@@ -144,7 +144,7 @@ def save_performance_midi(
                     ]
                 )
             ),
-            dtype=INT_TYPE,
+            dtype=int,
         )
 
         timepoints = []

--- a/partitura/io/importmatch.py
+++ b/partitura/io/importmatch.py
@@ -21,8 +21,6 @@ from partitura.utils import (
     iter_current_next,
     partition,
     estimate_clef_properties,
-    INT_TYPE,
-    FLOAT_TYPE
 )
 
 from partitura.performance import PerformedPart
@@ -144,7 +142,7 @@ class FractionalSymbolicDuration(object):
         if isinstance(sd, int):
             sd = FractionalSymbolicDuration(sd, 1)
 
-        dens = np.array([self.denominator, sd.denominator], dtype=INT_TYPE)
+        dens = np.array([self.denominator, sd.denominator], dtype=int)
         new_den = np.lcm(dens[0], dens[1])
         a_mult = new_den // dens
         new_num = np.dot(a_mult, [self.numerator, sd.numerator])

--- a/partitura/io/importmatch.py
+++ b/partitura/io/importmatch.py
@@ -1439,26 +1439,27 @@ def part_from_matchfile(mf, match_offset_duration_in_whole=True):
             / (note.Offset.denominator * (note.Offset.tuple_div or 1))
         )
 
-        # anacrusis
-        if bar_start < 0 and (bar_offset != 0 or beat_offset != 0):
+        # check anacrusis measure beat counting type for the first note
+        if (bar_start < 0 and (bar_offset != 0 or beat_offset != 0) and ni == 0):
             # in case of fully counted anacrusis we set the bar_start to -bar_duration (in
             # quarters) so that the below calculation is correct
             # not active for shortened anacrusis measures
             bar_start = -beats_map(bar_start) * 4 / beat_type_map(bar_start)
+            # reset the bar_start for other notes in the anacrusis measure
+            bar_times[note.Bar] = bar_start
 
         # convert the onset time in quarters (0 at first barline) to onset time in divs (0 at first note)
         onset_divs = int(round(divs * (bar_start + bar_offset + beat_offset - offset)))
 
-        # HACK use onset_in_divs[ni] if onset_in_divs does not match
-        # the correct time
+
         if not np.isclose(onset_divs, onset_in_divs[ni], atol=divs * 0.01):
             LOGGER.info(
                 "Calculated `onset_divs` does not match `OnsetInBeats` "
                 "information!."
             )
             onset_divs = onset_in_divs[ni]
-        # assert onset_divs >= 0
-        # assert np.isclose(onset_divs, onset_in_divs[ni], atol=divs * 0.01)
+        assert onset_divs >= 0
+        assert np.isclose(onset_divs, onset_in_divs[ni], atol=divs * 0.01)
 
         articulations = set()
         if "staccato" in note.ScoreAttributesList or "stac" in note.ScoreAttributesList:

--- a/partitura/io/importmatch.py
+++ b/partitura/io/importmatch.py
@@ -1449,8 +1449,16 @@ def part_from_matchfile(mf, match_offset_duration_in_whole=True):
         # convert the onset time in quarters (0 at first barline) to onset time in divs (0 at first note)
         onset_divs = int(round(divs * (bar_start + bar_offset + beat_offset - offset)))
 
-        assert onset_divs >= 0
-        assert np.isclose(onset_divs, onset_in_divs[ni], atol=divs * 0.01)
+        # HACK use onset_in_divs[ni] if onset_in_divs does not match
+        # the correct time
+        if not np.isclose(onset_divs, onset_in_divs[ni], atol=divs * 0.01):
+            LOGGER.info(
+                "Calculated `onset_divs` does not match `OnsetInBeats` "
+                "information!."
+            )
+            onset_divs = onset_in_divs[ni]
+        # assert onset_divs >= 0
+        # assert np.isclose(onset_divs, onset_in_divs[ni], atol=divs * 0.01)
 
         articulations = set()
         if "staccato" in note.ScoreAttributesList or "stac" in note.ScoreAttributesList:

--- a/partitura/io/importmidi.py
+++ b/partitura/io/importmidi.py
@@ -13,8 +13,6 @@ from partitura.utils import (
     key_name_to_fifths_mode,
     fifths_mode_to_key_name,
     estimate_clef_properties,
-    INT_TYPE,
-    FLOAT_TYPE
 )
 import partitura.musicanalysis as analysis
 
@@ -398,7 +396,7 @@ def load_score_midi(
     ]
     note_array = np.array(
         note_list,
-        dtype=[("onset_div", INT_TYPE), ("pitch", INT_TYPE), ("duration_div", INT_TYPE)],
+        dtype=[("onset_div", int), ("pitch", int), ("duration_div", int)],
     )
 
     LOGGER.debug("pitch spelling")
@@ -628,10 +626,10 @@ def create_part(
         warnings.warn("No time signatures found, assuming 4/4")
         time_sigs = [(0, 4, 4)]
 
-    time_sigs = np.array(time_sigs, dtype=INT_TYPE)
+    time_sigs = np.array(time_sigs, dtype=int)
 
     # for convenience we add the end times for each time signature
-    ts_end_times = np.r_[time_sigs[1:, 0], np.iinfo(INT_TYPE).max]
+    ts_end_times = np.r_[time_sigs[1:, 0], np.iinfo(int).max]
     time_sigs = np.column_stack((time_sigs, ts_end_times))
 
     LOGGER.debug("add time sigs and measures")

--- a/partitura/musicanalysis/pitch_spelling.py
+++ b/partitura/musicanalysis/pitch_spelling.py
@@ -9,7 +9,7 @@ References
 """
 import numpy as np
 from collections import namedtuple
-from partitura.utils import ensure_notearray, get_time_units_from_note_array, INT_TYPE, FLOAT_TYPE
+from partitura.utils import ensure_notearray, get_time_units_from_note_array
 
 # from partitura.musicanalysis.utils import prepare_notearray
 
@@ -21,7 +21,7 @@ ChromamorpheticPitch = namedtuple(
 )
 
 STEPS = np.array(["A", "B", "C", "D", "E", "F", "G"])
-UND_CHROMA = np.array([0, 2, 3, 5, 7, 8, 10], dtype=INT_TYPE)
+UND_CHROMA = np.array([0, 2, 3, 5, 7, 8, 10], dtype=int)
 ALTER = np.array(["n", "#", "b"])
 
 
@@ -64,7 +64,7 @@ def estimate_spelling(note_info, method="ps13s1", **kwargs):
     step, alter, octave = ps(ensure_notearray(note_info), **kwargs)
 
     spelling = np.empty(
-        len(step), dtype=[("step", "U1"), ("alter", INT_TYPE), ("octave", INT_TYPE)]
+        len(step), dtype=[("step", "U1"), ("alter", int), ("octave", int)]
     )
 
     spelling["step"] = step
@@ -137,7 +137,7 @@ def pitch_class_from_chroma(chroma):
 
 
 def compute_chroma_array(sorted_ocp):
-    return chroma_from_chromatic_pitch(sorted_ocp[:, 1]).astype(INT_TYPE)
+    return chroma_from_chromatic_pitch(sorted_ocp[:, 1]).astype(int)
 
 
 def compute_chroma_vector_array(chroma_array, K_pre, K_post):
@@ -146,7 +146,7 @@ def compute_chroma_vector_array(chroma_array, K_pre, K_post):
     each note.
     """
     n = len(chroma_array)
-    chroma_vector = np.zeros(12, dtype=INT_TYPE)
+    chroma_vector = np.zeros(12, dtype=int)
 
     for i in range(np.minimum(n, K_post)):
         chroma_vector[chroma_array[i]] = 1 + chroma_vector[chroma_array[i]]
@@ -173,18 +173,18 @@ def compute_morph_array(chroma_array, chroma_vector_array):
 
     n = len(chroma_array)
     # Line 1: Initialize morph array
-    morph_array = np.empty(n, dtype=INT_TYPE)
+    morph_array = np.empty(n, dtype=int)
 
     # Compute m0
     # Line 2
-    init_morph = np.array([0, 1, 1, 2, 2, 3, 4, 4, 5, 5, 6, 6], dtype=INT_TYPE)
+    init_morph = np.array([0, 1, 1, 2, 2, 3, 4, 4, 5, 5, 6, 6], dtype=int)
     # Line 3
     c0 = chroma_array[0]
     # Line 4
     m0 = init_morph[c0]
 
     # Line 5
-    morph_int = np.array([0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 6, 6], dtype=INT_TYPE)
+    morph_int = np.array([0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 6, 6], dtype=int)
 
     # Lines 6-8
     tonic_morph_for_tonic_chroma = np.mod(
@@ -195,7 +195,7 @@ def compute_morph_array(chroma_array, chroma_vector_array):
     tonic_chroma_set_for_morph = [[] for i in range(7)]
 
     # Line 11
-    morph_strength = np.zeros(7, dtype=INT_TYPE)
+    morph_strength = np.zeros(7, dtype=int)
 
     # Line 12
     for j in range(n):
@@ -235,7 +235,7 @@ def compute_ocm_chord_list(sorted_ocp, chroma_array, morph_array):
 
     # Lines 1-3
     ocm_array = np.column_stack((sorted_ocp[:, 0], chroma_array, morph_array)).astype(
-        INT_TYPE
+        int
     )
 
     # Alternative implementation of lines 4--9
@@ -266,7 +266,7 @@ def compute_morphetic_pitch(sorted_ocp, morph_array):
     chromatic_pitch = sorted_ocp[:, 1]
     morph = morph_array.reshape(-1, 1)
 
-    morph_oct_1 = np.floor(chromatic_pitch / 12.0).astype(INT_TYPE)
+    morph_oct_1 = np.floor(chromatic_pitch / 12.0).astype(int)
 
     morph_octs = np.column_stack((morph_oct_1, morph_oct_1 + 1, morph_oct_1 - 1))
 
@@ -280,7 +280,12 @@ def compute_morphetic_pitch(sorted_ocp, morph_array):
 
     best_morph_oct = morph_octs[np.arange(n), diffs.argmin(1)]
 
-    morphetic_pitch = morph.reshape(-1,) + 7 * best_morph_oct
+    morphetic_pitch = (
+        morph.reshape(
+            -1,
+        )
+        + 7 * best_morph_oct
+    )
 
     return morphetic_pitch
 

--- a/partitura/musicanalysis/tonal_tension.py
+++ b/partitura/musicanalysis/tonal_tension.py
@@ -20,7 +20,7 @@ from scipy.interpolate import interp1d
 
 from partitura.score import Part, PartGroup
 from partitura.performance import PerformedPart
-from partitura.utils import get_time_units_from_note_array, ensure_notearray, add_field, INT_TYPE, FLOAT_TYPE
+from partitura.utils import get_time_units_from_note_array, ensure_notearray, add_field
 
 
 __all__ = ["estimate_tonaltension"]
@@ -78,8 +78,8 @@ def ensure_norm(x):
 
 X, Y, Z = helical_to_cartesian(T)
 PITCH_COORDINATES = np.column_stack((X, Y, Z))
-MAJOR_IDXS = np.array([0, 1, 4], dtype=INT_TYPE)
-MINOR_IDXS = np.array([0, 1, -3], dtype=INT_TYPE)
+MAJOR_IDXS = np.array([0, 1, 4], dtype=int)
+MINOR_IDXS = np.array([0, 1, -3], dtype=int)
 
 # The scaling factor is the distance between C and B#, as used
 # in Cancino-Chacón and Grachten (2018)
@@ -326,7 +326,7 @@ def notes_to_idx(note_array):
     """
     note_idxs = np.array(
         [NOTES_BY_FIFTHS.index((n["step"], n["alter"])) for n in note_array],
-        dtype=INT_TYPE,
+        dtype=int,
     )
     return note_idxs
 
@@ -394,7 +394,7 @@ def key_map_from_keysignature(notearray, onset_unit="auto"):
     unique_onsets = np.unique(onsets)
     unique_onset_idxs = [np.where(onsets == u)[0] for u in unique_onsets]
 
-    kss = np.zeros((len(unique_onsets), 2), dtype=INT_TYPE)
+    kss = np.zeros((len(unique_onsets), 2), dtype=int)
 
     for i, uix in enumerate(unique_onset_idxs):
         # Deal with potential multiple key singatures in the same onset?
@@ -532,7 +532,7 @@ def estimate_tonaltension(
     # Perhaps add an automatic method in the future (for
     # inferring modulations?)
     km = key_map_from_keysignature(note_array, onset_unit=onset_unit)
-    fifths, mode = km(unique_onsets.min()).astype(INT_TYPE)
+    fifths, mode = km(unique_onsets.min()).astype(int)
     ts = TensileStrain(tonic_idx=C_IDX + fifths, mode=mode)
     # Initialize array for holding the tonal tension
     n_windows = len(unique_onsets)
@@ -559,7 +559,7 @@ def estimate_tonaltension(
         emi = set(np.where(score_offset <= max_time)[0])
 
         active_idx = np.array(
-            list(smi.intersection(emi).union(ema.intersection(sma))), dtype=INT_TYPE
+            list(smi.intersection(emi).union(ema.intersection(sma))), dtype=int
         )
         active_idx.sort()
 
@@ -570,7 +570,7 @@ def estimate_tonaltension(
 
         # Update key information
         if not np.all([fifths, mode] == km(o)):
-            fifths, mode = km(o).astype(INT_TYPE)
+            fifths, mode = km(o).astype(int)
             ts.update_key(tonic_idx=C_IDX + fifths, mode=mode)
 
         tonal_tension["cloud_diameter"][i] = cd.compute_tension(cloud)

--- a/partitura/musicanalysis/voice_separation.py
+++ b/partitura/musicanalysis/voice_separation.py
@@ -9,7 +9,7 @@ from statistics import mode
 import numpy as np
 from numpy import ma
 
-from partitura.utils import ensure_notearray, get_time_units_from_note_array, INT_TYPE, FLOAT_TYPE
+from partitura.utils import ensure_notearray, get_time_units_from_note_array
 
 # from partitura.musicanalysis.utils import prepare_notearray
 
@@ -144,7 +144,7 @@ def estimate_voices(note_info, monophonic_voices=False):
     v_notearray = VoSA(input_array).note_array
 
     # map the voices to the original notes
-    voices = np.empty(len(notearray), dtype=INT_TYPE)
+    voices = np.empty(len(notearray), dtype=int)
 
     for idx, voice in zip(v_notearray["id"], v_notearray["voice"]):
         voices[idx_equivs[idx]] = voice
@@ -274,7 +274,7 @@ def est_best_connections(cost, mode="prev"):
         mask[next_best, :] = 1
         mcost.mask = mask
 
-    best_assignment = np.array(best_assignment).astype(INT_TYPE)
+    best_assignment = np.array(best_assignment).astype(int)
 
     # Get unassigned streams
     unassigned_streams = list(set(range(n_streams)).difference(best_assignment[:, 0]))
@@ -990,8 +990,7 @@ class VoSA(VSBaseScore):
         Estimate voices using global minimum connections
         """
         # indices of the maximal contigs
-        maximal_contigs_idxs = np.where(
-            self._voices_per_contig == self.num_voices)[0]
+        maximal_contigs_idxs = np.where(self._voices_per_contig == self.num_voices)[0]
 
         # indices of the non maximal contigs
         non_maximal_contigs = self._voices_per_contig != self.num_voices

--- a/partitura/performance.py
+++ b/partitura/performance.py
@@ -12,7 +12,6 @@ import logging
 
 import numpy as np
 
-from partitura.utils import INT_TYPE, FLOAT_TYPE
 
 LOGGER = logging.getLogger(__name__)
 
@@ -161,12 +160,12 @@ class PerformedPart(object):
             n_ids = note_array["id"]
 
         if "track" not in note_array.dtype.names:
-            tracks = np.zeros(len(note_array), dtype=INT_TYPE)
+            tracks = np.zeros(len(note_array), dtype=int)
         else:
             tracks = note_array["track"]
 
         if "channel" not in note_array.dtype.names:
-            channels = np.ones(len(note_array), dtype=INT_TYPE)
+            channels = np.ones(len(note_array), dtype=int)
         else:
             channels = note_array["channel"]
 
@@ -190,7 +189,7 @@ class PerformedPart(object):
 
 def adjust_offsets_w_sustain(notes, controls, threshold=64):
     # get all note offsets
-    offs = np.fromiter((n["note_off"] for n in notes), dtype=FLOAT_TYPE)
+    offs = np.fromiter((n["note_off"] for n in notes), dtype=float)
     first_off = np.min(offs)
     last_off = np.max(offs)
 

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -2429,6 +2429,16 @@ def unfold_part_maximal(part, update_ids=True):
     part where all segments marked with repeat signs are included
     twice.
 
+    Parameters
+    ----------
+    part : :class:`Part`
+        The Part to unfold.
+    update_ids : bool (optional)
+        Update note ids to reflect the repetitions.
+        Note IDs will have a '-<repatition number>', e.g.,
+        'n132-1' and 'n132-2' represent the first and second
+        repetition of 'n132' in the input `part`.
+
     Returns
     -------
     unfolded_part : :class:`Part`
@@ -2445,9 +2455,17 @@ def unfold_part_maximal(part, update_ids=True):
 
 
 def unfold_part_alignment(part, alignment):
-    """Return the "maximally" unfolded part, that is, a copy of the
-    part where all segments marked with repeat signs are included
-    twice.
+    """Return the unfolded part given an alignment, that is, a copy
+    of the part where the segments are repeated according to the
+    repetitions in a performance.
+
+    Parameters
+    ----------
+    part : :class:`Part`
+        The Part to unfold.
+    alignment : list of dictionaries
+        List of dictionaries containing an alignment (like the ones
+        obtained from a MatchFile (see `alignment_from_matchfile`).
 
     Returns
     -------

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -2424,7 +2424,7 @@ def iter_unfolded_parts(part):
         yield sv.create_variant_part()
 
 
-def unfold_part_maximal(part, update_ids=True):
+def unfold_part_maximal(part, update_ids=False):
     """Return the "maximally" unfolded part, that is, a copy of the
     part where all segments marked with repeat signs are included
     twice.
@@ -2434,10 +2434,10 @@ def unfold_part_maximal(part, update_ids=True):
     part : :class:`Part`
         The Part to unfold.
     update_ids : bool (optional)
-        Update note ids to reflect the repetitions.
-        Note IDs will have a '-<repatition number>', e.g.,
-        'n132-1' and 'n132-2' represent the first and second
-        repetition of 'n132' in the input `part`.
+        Update note ids to reflect the repetitions. Note IDs will have
+        a '-<repetition number>', e.g., 'n132-1' and 'n132-2'
+        represent the first and second repetition of 'n132' in the
+        input `part`. Defaults to False.
 
     Returns
     -------

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -38,8 +38,6 @@ from partitura.utils import (
     to_quarter_tempo,
     key_mode_to_int,
     _OrderedSet,
-    INT_TYPE,
-    FLOAT_TYPE,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -237,7 +235,7 @@ class Part(object):
                 cur_bt = kp[1]
             if not keypoints_list or kp != keypoints_list[-1]:
                 keypoints_list.append([t] + kp)
-        keypoints = np.array(keypoints_list, dtype=FLOAT_TYPE)
+        keypoints = np.array(keypoints_list, dtype=float)
 
         x = keypoints[:, 0]
         y = np.r_[
@@ -2581,7 +2579,7 @@ def add_measures(part):
     """
 
     timesigs = np.array(
-        [(ts.start.t, ts.beats) for ts in part.iter_all(TimeSignature)], dtype=INT_TYPE
+        [(ts.start.t, ts.beats) for ts in part.iter_all(TimeSignature)], dtype=int
     )
 
     if len(timesigs) == 0:

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -38,6 +38,7 @@ from partitura.utils import (
     to_quarter_tempo,
     key_mode_to_int,
     _OrderedSet,
+    update_note_ids_after_unfolding,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -2423,20 +2424,67 @@ def iter_unfolded_parts(part):
         yield sv.create_variant_part()
 
 
-def unfold_part_maximal(part):
+def unfold_part_maximal(part, update_ids=True):
     """Return the "maximally" unfolded part, that is, a copy of the
     part where all segments marked with repeat signs are included
     twice.
 
     Returns
     -------
-    part : :class:`Part`
+    unfolded_part : :class:`Part`
         The unfolded Part
 
     """
 
     sv = make_score_variants(part)[-1]
-    return sv.create_variant_part()
+
+    unfolded_part = sv.create_variant_part()
+    if update_ids:
+        update_note_ids_after_unfolding(unfolded_part)
+    return unfolded_part
+
+
+def unfold_part_alignment(part, alignment):
+    """Return the "maximally" unfolded part, that is, a copy of the
+    part where all segments marked with repeat signs are included
+    twice.
+
+    Returns
+    -------
+    unfolded_part : :class:`Part`
+        The unfolded Part
+
+    """
+
+    unfolded_parts = []
+
+    alignment_ids = []
+
+    for n in alignment:
+        if n["label"] == "match" or n["label"] == "deletion":
+            alignment_ids.append(n["score_id"])
+
+    score_variants = make_score_variants(part)
+
+    alignment_score_ids = np.zeros((len(alignment_ids), len(score_variants)))
+    unfolded_part_length = np.zeros(len(score_variants))
+    for j, sv in enumerate(score_variants):
+        u_part = sv.create_variant_part()
+        update_note_ids_after_unfolding(u_part)
+        unfolded_parts.append(u_part)
+        u_part_ids = [n.id for n in u_part.notes_tied]
+        unfolded_part_length[j] = len(u_part_ids)
+        for i, aid in enumerate(alignment_ids):
+            alignment_score_ids[i, j] = aid in u_part_ids
+
+    coverage = np.mean(alignment_score_ids, 0)
+
+    best_idx = np.where(coverage == coverage.max())[0]
+
+    if len(best_idx) > 1:
+        best_idx = best_idx[unfolded_part_length[best_idx].argmin()]
+
+    return unfolded_parts[int(best_idx)]
 
 
 def make_score_variants(part):

--- a/partitura/utils/__init__.py
+++ b/partitura/utils/__init__.py
@@ -13,8 +13,6 @@ from partitura.utils.generic import (
     show_diff,
     search,
     _OrderedSet,
-    FLOAT_TYPE,
-    INT_TYPE
 )
 from partitura.utils.music import (
     MIDI_BASE_CLASS,

--- a/partitura/utils/__init__.py
+++ b/partitura/utils/__init__.py
@@ -38,6 +38,7 @@ from partitura.utils.music import (
     slice_notearray_by_time,
     note_array_from_part,
     get_time_units_from_note_array,
+    update_note_ids_after_unfolding,
 )
 
 __all__ = ["key_name_to_fifths_mode", "fifths_mode_to_key_name"]

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -10,10 +10,6 @@ LOGGER = logging.getLogger(__name__)
 __all__ = ["find_nearest", "iter_current_next", "partition", "iter_subclasses"]
 
 
-FLOAT_TYPE = float
-INT_TYPE = int
-
-
 class _OrderedSet(dict):
     def add(self, x):
         self[x] = None

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -1565,7 +1565,7 @@ def note_array_from_part(
             note_on_div,
             note_dur_div,
             note.midi_pitch,
-            note.voice,
+            note.voice if note.voice is not None else -1,
             note.id,
         )
 
@@ -1588,7 +1588,14 @@ def note_array_from_part(
 
         note_array.append(note_info)
 
-    return np.array(note_array, dtype=fields)
+    note_array = np.array(note_array, dtype=fields)
+
+    # Sanitize voice information
+    no_voice_idx = np.where(note_array['voice'] == -1)[0]
+    max_voice = note_array['voice'].max()
+    note_array['voice'][no_voice_idx] = max_voice + 1
+
+    return note_array
 
 
 if __name__ == "__main__":

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -1592,9 +1592,9 @@ def note_array_from_part(
     note_array = np.array(note_array, dtype=fields)
 
     # Sanitize voice information
-    no_voice_idx = np.where(note_array['voice'] == -1)[0]
-    max_voice = note_array['voice'].max()
-    note_array['voice'][no_voice_idx] = max_voice + 1
+    no_voice_idx = np.where(note_array["voice"] == -1)[0]
+    max_voice = note_array["voice"].max()
+    note_array["voice"][no_voice_idx] = max_voice + 1
 
     return note_array
 
@@ -1606,13 +1606,15 @@ def update_note_ids_after_unfolding(part):
     for n in part.notes:
         note_id_dict[n.id].append(n)
 
-    for nid in note_id_dict:
+    for nid, notes in note_id_dict.items():
 
-        notes = note_id_dict[nid]
+        if nid is None:
+            continue
+
         notes.sort(key=lambda x: x.start.t)
 
         for i, note in enumerate(notes):
-            note.id = f'{note.id}-{i+1}'
+            note.id = f"{note.id}-{i+1}"
 
 
 if __name__ == "__main__":

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.interpolate import interp1d
 from scipy.sparse import csc_matrix
 
-from partitura.utils.generic import find_nearest, search, iter_current_next, INT_TYPE, FLOAT_TYPE
+from partitura.utils.generic import find_nearest, search, iter_current_next
 
 LOGGER = logging.getLogger(__name__)
 
@@ -951,8 +951,8 @@ def _make_pianoroll(
     N = int(np.ceil(time_div * (2 * time_margin + max_time - min_time)))
 
     # Onset and offset times of the notes in the piano roll
-    pr_onset = np.round(time_div * onset).astype(INT_TYPE)
-    pr_offset = np.round(time_div * offset).astype(INT_TYPE)
+    pr_onset = np.round(time_div * onset).astype(int)
+    pr_offset = np.round(time_div * offset).astype(int)
 
     # Determine the non-zero indices of the piano roll
     if onset_only:
@@ -987,7 +987,7 @@ def _make_pianoroll(
 
     # Fill piano roll
     pianoroll = csc_matrix(
-        (idx_fill[:, 2], (idx_fill[:, 0], idx_fill[:, 1])), shape=(M, N), dtype=INT_TYPE
+        (idx_fill[:, 2], (idx_fill[:, 0], idx_fill[:, 1])), shape=(M, N), dtype=int
     )
 
     pr_idx_pitch_start = 0
@@ -999,7 +999,7 @@ def _make_pianoroll(
         # indices of each note in the piano roll
         pr_idx = np.column_stack(
             [pr_pitch - pr_idx_pitch_start, pr_onset, pr_offset]
-        ).astype(INT_TYPE)
+        ).astype(int)
         return pianoroll, pr_idx[idx.argsort()]
     else:
         return pianoroll
@@ -1359,11 +1359,7 @@ def note_array_from_part_list(
 
 
 def slice_notearray_by_time(
-    note_array,
-    start_time,
-    end_time,
-    time_unit="auto",
-    clip_onset_duration=True
+    note_array, start_time, end_time, time_unit="auto", clip_onset_duration=True
 ):
     """
     Get a slice of a structured note array by time

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import copy
 from collections import defaultdict
 import logging
 import numpy as np
@@ -1596,6 +1597,22 @@ def note_array_from_part(
     note_array['voice'][no_voice_idx] = max_voice + 1
 
     return note_array
+
+
+def update_note_ids_after_unfolding(part):
+
+    note_id_dict = defaultdict(list)
+
+    for n in part.notes:
+        note_id_dict[n.id].append(n)
+
+    for nid in note_id_dict:
+
+        notes = note_id_dict[nid]
+        notes.sort(key=lambda x: x.start.t)
+
+        for i, note in enumerate(notes):
+            note.id = f'{note.id}-{i+1}'
 
 
 if __name__ == "__main__":

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,8 +19,18 @@ MUSICXML_IMPORT_EXPORT_TESTFILES = [
     for fn in ["test_note_ties.xml", "test_note_ties_divs.xml"]
 ]
 MUSICXML_UNFOLD_TESTPAIRS = [
-    (os.path.join(MUSICXML_PATH, fn1), os.path.join(MUSICXML_PATH, fn2))
-    for fn1, fn2 in [("test_unfold_timeline.xml", "test_unfold_timeline_result.xml")]
+    (
+        os.path.join(MUSICXML_PATH, fn1),
+        os.path.join(MUSICXML_PATH, fn2),
+        os.path.join(MUSICXML_PATH, fn3),
+    )
+    for fn1, fn2, fn3 in [
+        (
+            "test_unfold_timeline.xml",
+            "test_unfold_timeline_result.xml",
+            "test_unfold_timeline_result_updated_ids.xml",
+        )
+    ]
 ]
 
 # This is a list of files for testing Chew and Wu's VOSA. (More files to come?)

--- a/tests/data/musicxml/test_unfold_timeline_result_updated_ids.xml
+++ b/tests/data/musicxml/test_unfold_timeline_result_updated_ids.xml
@@ -1,0 +1,93 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE score-partwise PUBLIC
+  "-//Recordare//DTD MusicXML 3.1 Partwise//EN"
+  "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <part-list>
+    <score-part id="P1">
+      <part-name>MüsicXML Part</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <!--=======================================================-->
+    <measure number="1">
+      <attributes>
+        <divisions>10</divisions>
+        <time>
+          <beats>2</beats>
+          <beat-type>4</beat-type>
+        </time>
+      </attributes>
+      <print new-page="yes" new-system="yes"/>
+      <note>
+        <rest/>
+        <duration>10</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note id="n01-1">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>10</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <fermata/>
+        </notations>
+      </note>
+      <note id="n02-1">
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>10</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <fermata/>
+      </barline>
+    </measure>
+    <!--=======================================================-->
+    <measure number="1">
+      <barline location="left">
+        <fermata/>
+      </barline>
+      <print new-page="yes" new-system="yes"/>
+      <note>
+        <rest/>
+        <duration>10</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note id="n01-2">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>10</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <notations>
+          <fermata/>
+        </notations>
+      </note>
+      <note id="n02-2">
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>10</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <fermata/>
+      </barline>
+    </measure>
+  </part>
+</score-partwise>

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -63,11 +63,24 @@ class TestMusicXML(unittest.TestCase):
                 self.assertTrue(equal, msg)
 
     def test_unfold_timeline(self):
-        for fn, fn_target in MUSICXML_UNFOLD_TESTPAIRS:
+        for fn, fn_target_1, fn_target_2 in MUSICXML_UNFOLD_TESTPAIRS:
             part = load_musicxml(fn, validate=False)
             part = score.unfold_part_maximal(part)
             result = save_musicxml(part).decode("UTF-8")
-            with open(fn_target) as f:
+            with open(fn_target_1) as f:
+                target = f.read()
+            equal = target == result
+            if not equal:
+                show_diff(result, target)
+            msg = "Unfolding part of MusicXML file {} does not yield expected result".format(
+                fn
+            )
+            self.assertTrue(equal, msg)
+
+            # check unfold with update_id
+            part = score.unfold_part_maximal(part, update_ids=True)
+            result = save_musicxml(part).decode("UTF-8")
+            with open(fn_target_2) as f:
                 target = f.read()
             equal = target == result
             if not equal:


### PR DESCRIPTION
This pull request includes 3 things:

1. Updates `musicxml_to_notearray` to work with the new fields in `note_array`s. The method is now analogous to `midi_to_notearray`, i.e., a simple and convenient way to load a MusicXML file into an array. This fixes the main part of issue #31. This is also addressed in commit e9d8439.
2. Fixed a bug when getting a `note_array` when no voice information is given (to avoid errors with `None` being casted as an integer). This was the specific problem with the MusicXML file that motivated the issue. This is also addressed in commit 
e9d8439.
3. Fixed a bug when creating `Part`s from MatchFiles (which was one of the motivations of the the original discussion @melkisedeath and @nimrodVarga that motivated the Issue). This is addressed in commit d47ba42.