### PR TITLE
Update unfold part

### DIFF
--- a/partitura/score.py
+++ b/partitura/score.py
@@ -2431,6 +2431,16 @@ def unfold_part_maximal(part, update_ids=True):
     part where all segments marked with repeat signs are included
     twice.
 
+    Parameters
+    ----------
+    part : :class:`Part`
+        The Part to unfold.
+    update_ids : bool (optional)
+        Update note ids to reflect the repetitions.
+        Note IDs will have a '-<repatition number>', e.g.,
+        'n132-1' and 'n132-2' represent the first and second
+        repetition of 'n132' in the input `part`.
+
     Returns
     -------
     unfolded_part : :class:`Part`
@@ -2447,9 +2457,17 @@ def unfold_part_maximal(part, update_ids=True):
 
 
 def unfold_part_alignment(part, alignment):
-    """Return the "maximally" unfolded part, that is, a copy of the
-    part where all segments marked with repeat signs are included
-    twice.
+    """Return the unfolded part given an alignment, that is, a copy
+    of the part where the segments are repeated according to the
+    repetitions in a performance.
+
+    Parameters
+    ----------
+    part : :class:`Part`
+        The Part to unfold.
+    alignment : list of dictionaries
+        List of dictionaries containing an alignment (like the ones
+        obtained from a MatchFile (see `alignment_from_matchfile`).
 
     Returns
     -------

--- a/partitura/utils/__init__.py
+++ b/partitura/utils/__init__.py
@@ -40,6 +40,7 @@ from partitura.utils.music import (
     slice_notearray_by_time,
     note_array_from_part,
     get_time_units_from_note_array,
+    update_note_ids_after_unfolding,
 )
 
 __all__ = ["key_name_to_fifths_mode", "fifths_mode_to_key_name"]

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import copy
 from collections import defaultdict
 import logging
 import numpy as np
@@ -1600,6 +1601,22 @@ def note_array_from_part(
     note_array['voice'][no_voice_idx] = max_voice + 1
 
     return note_array
+
+
+def update_note_ids_after_unfolding(part):
+
+    note_id_dict = defaultdict(list)
+
+    for n in part.notes:
+        note_id_dict[n.id].append(n)
+
+    for nid in note_id_dict:
+
+        notes = note_id_dict[nid]
+        notes.sort(key=lambda x: x.start.t)
+
+        for i, note in enumerate(notes):
+            note.id = f'{note.id}-{i+1}'
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This branch has 2 contributions:

1. Adds an option to `unfold_part_maximal` to update the note IDs to reflect the repetition structure. The updated note IDs follow the conventions from the Magaloff/Zeilinger dataset (i.e., `n123-1` and `n123-2` are the first and second repetitions of note `n123`)
2. Adds a method for unfold a part given an alignment (`unfold_part_alignment`). The method relies on `make_score_variants`, and thus, does not currently support nested repeats, Da Capo/Fine etc.