### PR TITLE
added unzipping for compressed musicxml files from musescore

### DIFF
--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -7,6 +7,9 @@ import logging
 import numpy as np
 from lxml import etree
 
+import os
+import zipfile
+
 # lxml does XSD validation too but has problems with the MusicXML 3.1 XSD, so we use
 # the xmlschema package for validating MusicXML against the definition
 import xmlschema
@@ -187,6 +190,11 @@ def load_musicxml(xml, ensure_list=False, validate=False, force_note_ids=None):
         A list of either Part or PartGroup objects
 
     """
+    
+    if os.path.basename(xml).endswith(".mxl"):
+        with zipfile.ZipFile(xml) as zipped_xml:
+            xml = zipped_xml.open(os.path.basename(xml).split(".")[0]+".xml")
+
     if validate:
         validate_musicxml(xml, debug=True)
         # if xml is a file-like object we need to set the read pointer to the

--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -191,9 +191,10 @@ def load_musicxml(xml, ensure_list=False, validate=False, force_note_ids=None):
 
     """
     
-    if os.path.basename(xml).endswith(".mxl"):
-        with zipfile.ZipFile(xml) as zipped_xml:
-            xml = zipped_xml.open(os.path.basename(xml).split(".")[0]+".xml")
+    if type(xml) == str:
+        if zipfile.is_zipfile(xml):
+            with zipfile.ZipFile(xml) as zipped_xml:
+                xml = zipped_xml.open(os.path.splitext(os.path.basename(xml))[0]+".xml")
 
     if validate:
         validate_musicxml(xml, debug=True)


### PR DESCRIPTION
this change assumes a main musicxml file in the zipped container with the same file name as the .mxl file and the extension .xml. As far as I can tell this is the case for compressed musicxml files exported from musescore.