### PR TITLE
Fix Issue #83

### DIFF
--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -1021,11 +1021,8 @@ def _make_pianoroll(
             raise ValueError(
                 "`min_time` must be smaller or equal than " "the smallest onset time "
             )
-    # max_time = np.max(offset)
 
-    # onset -= min_time  - time_margin
     onset -= min_time
-    # offset -= min_time - time_margin
 
     if pitch_margin > -1:
         pr_pitch -= lowest_pitch
@@ -1040,26 +1037,16 @@ def _make_pianoroll(
 
     # Onset and offset times of the notes in the piano roll
     pr_onset = np.round(time_div * onset).astype(int)
-    pr_onset -= int(time_margin * time_div)
-    pr_duration = np.round(time_div * duration).astype(int)
-    np.clip(pr_duration,
-            a_max=None,
-            a_min=1,
-            out=pr_duration
-            )
+    pr_onset += int(time_margin * time_div)
+    pr_duration = np.clip(
+        np.round(time_div * duration).astype(int),
+        a_max=None,
+        a_min=1
+    )
     pr_offset = pr_onset + pr_duration
-    # pr_offset = np.round(time_div * offset).astype(int)
 
     # Time dimension
-    # N = int(np.ceil(time_div * (2 * time_margin + max_time - min_time)))
-    N = int(2 * time_div * time_margin + pr_offset.max())
-
-    # if pr_onset.max() == pr_offset.max():
-    #     # In case the last onset and last offset fall into the same bin
-    #     # due to the resolution of the piano roll, give the last
-    #     # note at least a duration of 1 bin
-    #     pr_offset[pr_offset == pr_offset.max()] += 1
-    #     N += 1
+    N = int(time_div * time_margin + pr_offset.max())
 
     # Determine the non-zero indices of the piano roll
     if onset_only:
@@ -1093,13 +1080,9 @@ def _make_pianoroll(
         idx_fill[i] = np.array([row, column, max(vel)])
 
     # Fill piano roll
-    try:
-        pianoroll = csc_matrix(
-            (idx_fill[:, 2], (idx_fill[:, 0], idx_fill[:, 1])), shape=(M, N), dtype=int
-        )
-    except:
-        import pdb
-        pdb.set_trace()
+    pianoroll = csc_matrix(
+        (idx_fill[:, 2], (idx_fill[:, 0], idx_fill[:, 1])), shape=(M, N), dtype=int
+    )
 
     pr_idx_pitch_start = 0
     if piano_range:

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -984,7 +984,6 @@ def _make_pianoroll(
     # Get pitch, onset, offset from the note_info array
     pr_pitch = note_info[:, 0]
     onset = note_info[:, 1]
-    # offset = note_info[:, 1] + note_info[:, 2]
     duration = note_info[:, 2]
 
     if np.any(duration < 0):
@@ -1011,7 +1010,7 @@ def _make_pianoroll(
     # sort notes
     pr_pitch = pr_pitch[idx]
     onset = onset[idx]
-    # offset = offset[idx]
+
     if min_time is None:
         min_time = 0 if min(onset) >= 0 else min(onset)
         if remove_silence:
@@ -1065,7 +1064,6 @@ def _make_pianoroll(
                 for on, off, pitch, vel in zip(
                     pr_onset, pr_offset, pr_pitch, pr_velocity
                 )
-                # if off <= N
             ]
         )
 

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -1040,6 +1040,13 @@ def _make_pianoroll(
     pr_onset = np.round(time_div * onset).astype(int)
     pr_offset = np.round(time_div * offset).astype(int)
 
+    if pr_onset.max() == pr_offset.max():
+        # In case the last onset and last offset fall into the same bin
+        # due to the resolution of the piano roll, give the last
+        # note at least a duration of 1 bin
+        pr_offset[pr_offset == pr_offset.max()] += 1
+        N += 1
+
     # Determine the non-zero indices of the piano roll
     if onset_only:
         _idx_fill = np.column_stack([pr_pitch, pr_onset, pr_velocity])
@@ -1075,6 +1082,7 @@ def _make_pianoroll(
     pianoroll = csc_matrix(
         (idx_fill[:, 2], (idx_fill[:, 0], idx_fill[:, 1])), shape=(M, N), dtype=int
     )
+    
 
     pr_idx_pitch_start = 0
     if piano_range:

--- a/tests/test_pianoroll.py
+++ b/tests/test_pianoroll.py
@@ -4,6 +4,9 @@ import logging
 import unittest
 
 from partitura.utils.music import compute_pianoroll, pianoroll_to_notearray
+from partitura import load_musicxml
+
+from tests import MUSICXML_IMPORT_EXPORT_TESTFILES
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +45,48 @@ class TestPianorollFromNotes(unittest.TestCase):
 
         equal = np.all(pr.toarray() == expected_pr)
 
-        self.assertEqual(equal, True)
+        self.assertTrue(equal)
+
+    def test_performance_pianoroll_onset_only(self):
+        note_array = np.array(
+            [(60, 0, 1, 72)],
+            dtype=[
+                ("pitch", "i4"),
+                ("onset_sec", "f4"),
+                ("duration_sec", "f4"),
+                ("velocity", "i4"),
+            ],
+        )
+
+        pr = compute_pianoroll(note_array, pitch_margin=2, time_div=2, onset_only=True)
+        expected_pr = np.array([[0, 0], [0, 0], [72, 0], [0, 0], [0, 0]])
+
+        equal = np.all(pr.toarray() == expected_pr)
+
+        self.assertTrue(equal)
+
+    def test_noteduration_pianoroll(self):
+        note_array = np.array(
+            [(60, 0, 2),
+             (60, 2, 2),
+             (60, 5, 0.3)],
+            dtype=[("pitch", "i4"), ("onset_beat", "f4"), ("duration_beat", "f4")],
+        )
+
+        pr = compute_pianoroll(note_array, pitch_margin=2, time_div=1, onset_only=True)
+
+        expected_pr = np.array(
+            [
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0],
+                [1, 0, 1, 0, 0, 1],
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0]
+            ]
+        )
+
+        equal = np.all(pr.toarray() == expected_pr)
+        self.assertTrue(equal)
 
 
 class TestNotesFromPianoroll(unittest.TestCase):
@@ -85,6 +129,78 @@ class TestNotesFromPianoroll(unittest.TestCase):
         rec_note_array = rec_note_array[rec_onset_idx]
 
         test = np.all(note_array == rec_note_array)
-        print(note_array)
-        print(rec_note_array)
-        self.assertEqual(test, True)
+        self.assertTrue(test)
+
+    def test_reconstruction_score(self):
+
+        for fn in MUSICXML_IMPORT_EXPORT_TESTFILES:
+            spart = load_musicxml(fn)
+            note_array = spart.note_array
+            pr = compute_pianoroll(spart, time_unit="div", time_div=1, remove_silence=False)
+
+            rec_note_array = pianoroll_to_notearray(pr, time_div=1, time_unit="div")
+
+            original_pitch_idx = np.argsort(note_array["pitch"])
+            note_array = note_array[original_pitch_idx]
+            original_onset_idx = np.argsort(note_array["onset_div"], kind="mergesort")
+            note_array = note_array[original_onset_idx]
+
+            rec_pitch_idx = np.argsort(rec_note_array["pitch"])
+            rec_note_array = rec_note_array[rec_pitch_idx]
+            rec_onset_idx = np.argsort(rec_note_array["onset_div"], kind="mergesort")
+            rec_note_array = rec_note_array[rec_onset_idx]
+
+            test_pitch = np.all(note_array['pitch'] == rec_note_array['pitch'])
+            self.assertTrue(test_pitch)
+            test_onset = np.all(note_array['onset_div'] == rec_note_array['onset_div'])
+            self.assertTrue(test_onset)
+            test_duration = np.all(note_array['duration_div'] == rec_note_array['duration_div'])
+            self.assertTrue(test_duration)
+
+    def test_reconstruction_perf(self):
+
+        rng = np.random.RandomState(1984)
+        piece_length = 11
+        for i in range(10):
+
+            note_array = np.zeros(
+                piece_length,
+                dtype=[
+                    ("pitch", "i4"),
+                    ("onset_sec", "f4"),
+                    ("duration_sec", "f4"),
+                    ("velocity", "i4"),
+                    ("id", "U256")
+                ]
+            )
+
+            note_array['pitch'] = rng.randint(0, 127, piece_length)
+            note_array['duration_sec'] = np.clip(np.round(rng.rand(piece_length) * 2, 2),
+                                                 a_max=None,
+                                                 a_min=0.01)
+
+            onset = np.round(np.r_[0, np.cumsum(note_array['duration_sec'] + 0.02)], 2)
+            note_array['onset_sec'] = onset[:-1]
+            note_array['velocity'] = rng.randint(20, 127, piece_length)
+            note_array['id'] = np.array([f'n{nid}' for nid in range(piece_length)])
+
+            pr = compute_pianoroll(note_array, time_unit="sec", time_div=100,
+                                   remove_silence=False)
+
+            rec_note_array = pianoroll_to_notearray(pr, time_div=100, time_unit="sec")
+            rec_pr = compute_pianoroll(rec_note_array, time_unit="sec", time_div=100,
+                                       remove_silence=False)
+
+            # assert piano rolls are the same
+            self.assertTrue(np.all(rec_pr.toarray() == pr.toarray()))
+
+            # assert note arrays are the same
+            test_pitch = np.all(note_array['pitch'] == rec_note_array['pitch'])
+            print(note_array['pitch'], rec_note_array['pitch'])
+            self.assertTrue(test_pitch)
+            test_onset = np.all(note_array['onset_sec'] == rec_note_array['onset_sec'])
+            self.assertTrue(test_onset)
+            test_duration = np.all(note_array['duration_sec'] == rec_note_array['duration_sec'])
+            self.assertTrue(test_duration)
+            test_velocity = np.all(note_array['velocity'] == rec_note_array['velocity'])
+            self.assertTrue(test_velocity)

--- a/tests/test_pianoroll.py
+++ b/tests/test_pianoroll.py
@@ -58,8 +58,18 @@ class TestPianorollFromNotes(unittest.TestCase):
             ],
         )
 
-        pr = compute_pianoroll(note_array, pitch_margin=2, time_div=2, onset_only=True)
-        expected_pr = np.array([[0, 0], [0, 0], [72, 0], [0, 0], [0, 0]])
+        pr = compute_pianoroll(note_array, pitch_margin=3, time_div=2, onset_only=True)
+        expected_pr = np.array(
+            [
+                [0, 0],
+                [0, 0],
+                [0, 0],
+                [72, 0],
+                [0, 0],
+                [0, 0],
+                [0, 0]
+            ]
+        )
 
         equal = np.all(pr.toarray() == expected_pr)
 
@@ -87,6 +97,33 @@ class TestPianorollFromNotes(unittest.TestCase):
 
         equal = np.all(pr.toarray() == expected_pr)
         self.assertTrue(equal)
+
+    def test_time_margin_pianoroll(self):
+        note_array = np.array(
+            [(60, 0, 2),
+             (60, 2, 2),
+             (60, 5, 0.3)],
+            dtype=[("pitch", "i4"), ("onset_beat", "f4"), ("duration_beat", "f4")],
+        )
+
+        for tm in range(10):
+            pr = compute_pianoroll(note_array, pitch_margin=2, time_div=1,
+                                   time_margin=tm, onset_only=True)
+
+            expected_pr = np.array(
+                [
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [1, 0, 1, 0, 0, 1],
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0]
+                ]
+            )
+
+            time_margins = np.zeros((5, tm))
+            expected_pr = np.column_stack((time_margins, expected_pr, time_margins))
+            equal = np.all(pr.toarray() == expected_pr)
+            self.assertTrue(equal)
 
 
 class TestNotesFromPianoroll(unittest.TestCase):
@@ -175,9 +212,11 @@ class TestNotesFromPianoroll(unittest.TestCase):
             )
 
             note_array['pitch'] = rng.randint(0, 127, piece_length)
-            note_array['duration_sec'] = np.clip(np.round(rng.rand(piece_length) * 2, 2),
-                                                 a_max=None,
-                                                 a_min=0.01)
+            note_array['duration_sec'] = np.clip(
+                np.round(rng.rand(piece_length) * 2, 2),
+                a_max=None,
+                a_min=0.01
+            )
 
             onset = np.round(np.r_[0, np.cumsum(note_array['duration_sec'] + 0.02)], 2)
             note_array['onset_sec'] = onset[:-1]
@@ -196,7 +235,6 @@ class TestNotesFromPianoroll(unittest.TestCase):
 
             # assert note arrays are the same
             test_pitch = np.all(note_array['pitch'] == rec_note_array['pitch'])
-            print(note_array['pitch'], rec_note_array['pitch'])
             self.assertTrue(test_pitch)
             test_onset = np.all(note_array['onset_sec'] == rec_note_array['onset_sec'])
             self.assertTrue(test_onset)


### PR DESCRIPTION
This pull request solves an issue generating piano rolls. Due to the resolution of the piano roll (specified by the `time_div` argument), it could sometimes happen that the last onset and the last offset fall in the same cell/pixel (i.e., the last note would have a "duration" of 0 cells/pixel). In the fixed version, all notes have a minimum duration of one cell/pixel.

This pull request includes more tests tests for creating piano rolls and reconstructing note arrays from piano rolls.