### PR TITLE
Replaced logging Logger by warnings

### DIFF
--- a/partitura/directions.py
+++ b/partitura/directions.py
@@ -12,17 +12,16 @@ The functionality is provided by the function `parse_words`
 """
 
 import re
-import logging
-
+import warnings
 try:
     from lark import Lark
 
     HAVE_LARK = True
 except ImportError:
-    logging.getLogger(__name__).warning(
+    warnings.warn(
         '''package "lark" not found; Textual directions will not be
 parsed to form `score.Direction` objects but included as `score.Words`
-instead; Install using "pip install lark-parser"'''
+instead; Install using "pip install lark-parser"''', ImportWarning, stacklevel=2
     )
     HAVE_LARK = False
 
@@ -34,8 +33,6 @@ __all__ = ["parse_direction"]
 # convert: '{}'.format(roman.fromRoman(t.value.upper()))
 
 import partitura.score as score
-
-LOGGER = logging.getLogger(__name__)
 
 
 def join_items(items):
@@ -449,7 +446,7 @@ def create_directions(tree, string, start=None, end=None):
         return [score.Words(string[start:end])]
 
     else:
-        LOGGER.warning("unhandled: {}".format(string[start:end]))
+        warnings.warn("unhandled: {}".format(string[start:end]))
         return [score.Words(string[start:end])]
 
 
@@ -530,7 +527,7 @@ def parse_direction(string):
             parse_result = DEFAULT_PARSER.parse(string)
             direction = create_directions(parse_result, string)
         except Exception as e:
-            LOGGER.warning('error parsing "{}" ({})'.format(string, type(e).__name__))
+            warnings.warn('error parsing "{}" ({})'.format(string, type(e).__name__))
             direction = [score.Words(string)]
     else:
         direction = [score.Words(string)]

--- a/partitura/display.py
+++ b/partitura/display.py
@@ -7,7 +7,7 @@ application.
 """
 
 import platform
-import logging
+import warnings
 import os
 import subprocess
 from tempfile import NamedTemporaryFile, TemporaryFile
@@ -15,7 +15,7 @@ from tempfile import NamedTemporaryFile, TemporaryFile
 from partitura import save_musicxml
 from partitura.io.musescore import render_musescore
 
-LOGGER = logging.getLogger(__name__)
+
 
 __all__ = ["render"]
 
@@ -103,12 +103,12 @@ def render_lilypond(part, fmt="png"):
                 cmd1, stdin=xml_fh, stdout=subprocess.PIPE, check=False
             )
             if ps1.returncode != 0:
-                LOGGER.error(
-                    "Command {} failed with code {}".format(cmd1, ps1.returncode)
+                warnings.warn(
+                    "Command {} failed with code {}".format(cmd1, ps1.returncode), stacklevel=2
                 )
                 return None
         except FileNotFoundError as f:
-            LOGGER.error('Executing "{}" returned  {}.'.format(" ".join(cmd1), f))
+            warnings.warn('Executing "{}" returned  {}.'.format(" ".join(cmd1), f), ImportWarning, stacklevel=2)
             return None
 
         # convert lilypond format (read from pipe of ps1) to image, and save to
@@ -124,12 +124,12 @@ def render_lilypond(part, fmt="png"):
         try:
             ps2 = subprocess.run(cmd2, input=ps1.stdout, check=False)
             if ps2.returncode != 0:
-                LOGGER.error(
-                    "Command {} failed with code {}".format(cmd2, ps2.returncode)
+                warnings.warn(
+                    "Command {} failed with code {}".format(cmd2, ps2.returncode), stacklevel=2
                 )
                 return None
         except FileNotFoundError as f:
-            LOGGER.error('Executing "{}" returned {}.'.format(" ".join(cmd2), f))
+            warnings.warn('Executing "{}" returned {}.'.format(" ".join(cmd2), f), ImportWarning, stacklevel=2)
             return
 
         return img_fh.name

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -3,7 +3,6 @@
 """
 This module contains methods for exporting matchfiles
 """
-import logging
 import numpy as np
 
 from scipy.interpolate import interp1d
@@ -27,7 +26,6 @@ from partitura.utils.music import midi_pitch_to_pitch_spelling, MAJOR_KEYS, MINO
 
 __all__ = ["save_match"]
 
-LOGGER = logging.getLogger(__name__)
 
 
 def seconds_to_midi_ticks(t, mpq=500000, ppq=480):

--- a/partitura/io/exportmidi.py
+++ b/partitura/io/exportmidi.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import logging
 import numpy as np
 
 from collections import defaultdict, OrderedDict
@@ -10,8 +9,6 @@ import partitura.score as score
 from partitura.utils import partition
 
 __all__ = ["save_score_midi", "save_performance_midi"]
-
-LOGGER = logging.getLogger(__name__)
 
 
 def get_partgroup(part):

--- a/partitura/io/exportmusicxml.py
+++ b/partitura/io/exportmusicxml.py
@@ -3,7 +3,6 @@
 import math
 from collections import defaultdict
 from lxml import etree
-import logging
 import partitura.score as score
 from operator import itemgetter
 
@@ -11,8 +10,6 @@ from .importmusicxml import DYN_DIRECTIONS, PEDAL_DIRECTIONS
 from partitura.utils import partition, iter_current_next, to_quarter_tempo
 
 __all__ = ["save_musicxml"]
-
-LOGGER = logging.getLogger(__name__)
 
 DOCTYPE = """<!DOCTYPE score-partwise PUBLIC\n  "-//Recordare//DTD MusicXML 3.1 Partwise//EN"\n  "http://www.musicxml.org/dtds/partwise.dtd">"""  # noqa: E501
 MEASURE_SEP_COMMENT = "======================================================="

--- a/partitura/io/importmatch.py
+++ b/partitura/io/importmatch.py
@@ -7,6 +7,7 @@ import re
 from fractions import Fraction
 from operator import attrgetter, itemgetter
 import logging
+import warnings
 
 import numpy as np
 from scipy.interpolate import interp1d
@@ -28,7 +29,7 @@ import partitura.score as score
 from partitura.musicanalysis import estimate_voices, estimate_key
 
 __all__ = ["load_match"]
-LOGGER = logging.getLogger(__name__)
+
 
 rational_pattern = re.compile(r"^([0-9]+)/([0-9]+)$")
 double_rational_pattern = re.compile(r"^([0-9]+)/([0-9]+)/([0-9]+)$")
@@ -1468,7 +1469,7 @@ def part_from_matchfile(mf, match_offset_duration_in_whole=True):
         onset_divs = int(round(divs * (bar_start + bar_offset + beat_offset - offset)))
 
         if not np.isclose(onset_divs, onset_in_divs[ni], atol=divs * 0.01):
-            LOGGER.info(
+            warnings.warn(
                 "Calculated `onset_divs` does not match `OnsetInBeats` "
                 "information!."
             )

--- a/partitura/io/importmei.py
+++ b/partitura/io/importmei.py
@@ -8,11 +8,11 @@ from partitura.utils.music import (
     estimate_symbolic_duration,
 )
 
-import logging
+import warnings
 
 import numpy as np
 
-LOGGER = logging.getLogger(__name__)
+
 
 
 def load_mei(mei_path: str) -> list:
@@ -193,10 +193,10 @@ class MeiParser:
                 fifths = self._mei_sig_to_fifths(sig)
                 mode = anc.get("key.mode")
             else:
-                LOGGER.warning(
+                warnings.warn(
                     f"The key signature is not encoded in {staffdef_el.get(self._ns_name('id'))} or in any ancestor scoreDef."
                 )
-                LOGGER.warning("A default key signature of C maj is set.")
+                warnings.warn("A default key signature of C maj is set.")
                 fifths = 0
                 mode = "major"
 
@@ -253,7 +253,7 @@ class MeiParser:
                         element.get("dis"), element.get("dis.place")
                     )
                 else:  # no clef info available, go for default
-                    LOGGER.warning("No clef information found, setting G2 as default.")
+                    warnings.warn("No clef information found, setting G2 as default.")
                     sign = "G"
                     line = 2
                     number = 1
@@ -782,7 +782,7 @@ class MeiParser:
             )
         # check if layers have equal duration (bad encoding, but it often happens)
         if not all([e == end_positions[0] for e in end_positions]):
-            LOGGER.warning(
+            warnings.warn(
                 f"Warning: voices have different durations in staff {staff_el.attrib[self._ns_name('id',XML_NAMESPACE)]}"
             )
 
@@ -821,7 +821,7 @@ class MeiParser:
                     )
                 # sanity check that all layers have equal duration
                 if not all([e == end_positions[0] for e in end_positions]):
-                    LOGGER.warning(
+                    warnings.warn(
                         f"Warning : parts have measures of different duration in measure {element.attrib[self._ns_name('id',XML_NAMESPACE)]}"
                     )
                 position = max(end_positions)
@@ -875,7 +875,7 @@ class MeiParser:
             start_id = tie_el.get("startid")
             end_id = tie_el.get("endid")
             if start_id is None or end_id is None:
-                LOGGER.warning(
+                warnings.warn(
                     f"Warning: tie {tie_el.attrib[self._ns_name('id',XML_NAMESPACE)]} is missing the a startid or endid"
                 )
             else:

--- a/partitura/io/importmidi.py
+++ b/partitura/io/importmidi.py
@@ -2,7 +2,6 @@
 import numpy as np
 from collections import defaultdict
 import warnings
-import logging
 
 import mido
 
@@ -18,7 +17,6 @@ import partitura.musicanalysis as analysis
 
 __all__ = ["load_score_midi", "load_performance_midi"]
 
-LOGGER = logging.getLogger(__name__)
 
 
 # as key for the dict use channel * 128 (max number of pitches) + pitch
@@ -114,7 +112,7 @@ def load_performance_midi(fn, default_bpm=120, merge_tracks=False):
 
                 time_conversion_factor = mpq / (ppq * 10 ** 6)
 
-                LOGGER.info(
+                warnings.warn(
                     (
                         "change of Tempo to mpq = {0} "
                         " and resulting seconds per tick = {1}"
@@ -415,11 +413,11 @@ or a list of these
         dtype=[("onset_div", int), ("pitch", int), ("duration_div", int)],
     )
 
-    LOGGER.debug("pitch spelling")
+    warnings.warn("pitch spelling")
     spelling_global = analysis.estimate_spelling(note_array)
 
     if estimate_voice_info:
-        LOGGER.debug("voice estimation")
+        warnings.warn("voice estimation", stacklevel=2)
         # TODO: deal with zero duration notes in note_array.
         # Zero duration notes are currently deleted
         estimated_voices = analysis.estimate_voices(note_array)
@@ -429,7 +427,7 @@ or a list of these
                 part_voice[1] = voice_est
 
     if estimate_key:
-        LOGGER.debug("key estimation")
+        warnings.warn("key estimation", stacklevel=2)
         _, mode, fifths = analysis.estimate_key(note_array)
         key_sigs_by_track = {}
         global_key_sigs = [(0, fifths_mode_to_key_name(fifths, mode))]
@@ -599,7 +597,7 @@ def create_part(
     part_id=None,
     part_name=None,
 ):
-    LOGGER.debug("create_part")
+    warnings.warn("create_part", stacklevel=2)
 
     part = score.Part(part_id, part_name=part_name)
     part.set_quarter_duration(0, ticks)
@@ -612,7 +610,7 @@ def create_part(
         fifths, mode = key_name_to_fifths_mode(name)
         part.add(score.KeySignature(fifths, mode), t)
 
-    LOGGER.debug("add notes")
+    warnings.warn("add notes", stacklevel=2)
 
     for (onset, pitch, duration), (step, alter, octave), voice, note_id in zip(
         notes, spellings, voices, note_ids
@@ -649,7 +647,7 @@ def create_part(
     ts_end_times = np.r_[time_sigs[1:, 0], np.iinfo(int).max]
     time_sigs = np.column_stack((time_sigs, ts_end_times))
 
-    LOGGER.debug("add time sigs and measures")
+    warnings.warn("add time sigs and measures", stacklevel=2)
 
     for ts_start, num, den, ts_end in time_sigs:
         time_sig = score.TimeSignature(num.item(), den.item())
@@ -676,16 +674,16 @@ def create_part(
     #     if np.isinf(ts_end):
     #         ts_end = m_end
 
-    LOGGER.debug("tie notes")
+    warnings.warn("tie notes", stacklevel=2)
     # tie notes where necessary (across measure boundaries, and within measures
     # notes with compound duration)
     score.tie_notes(part)
 
-    LOGGER.debug("find tuplets")
+    warnings.warn("find tuplets", stacklevel=2)
     # apply simplistic tuplet finding heuristic
     score.find_tuplets(part)
 
-    LOGGER.debug("done create_part")
+    warnings.warn("done create_part", stacklevel=2)
     return part
 
 

--- a/partitura/io/importnakamura.py
+++ b/partitura/io/importnakamura.py
@@ -9,14 +9,13 @@ References
        Detection and Post-Processing for Fast and Accurate Symbolic Music
        Alignment"
 """
-import logging
+import warnings
 import re
 import numpy as np
 
 from partitura.utils import note_name_to_midi_pitch
 from partitura.utils.music import SIGN_TO_ALTER
 
-LOGGER = logging.getLogger(__name__)
 
 NAME_PATT = re.compile(r"([A-G]{1})([xb\#]*)(\d+)")
 

--- a/partitura/io/musescore.py
+++ b/partitura/io/musescore.py
@@ -6,7 +6,7 @@ backend for loading and rendering scores.
 """
 
 import platform
-import logging
+import warnings
 import os
 import shutil
 import subprocess
@@ -16,7 +16,6 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
 from partitura.io.importmusicxml import load_musicxml
 from partitura.io.exportmusicxml import save_musicxml
 
-LOGGER = logging.getLogger(__name__)
 
 
 class MuseScoreNotFoundException(Exception):
@@ -160,7 +159,7 @@ def render_musescore(part, fmt, out_fn=None, dpi=90):
 
     if fmt not in ("png", "pdf"):
 
-        LOGGER.warning("warning: unsupported output format")
+        warnings.warn("warning: unsupported output format")
         return None
 
     # with NamedTemporaryFile(suffix='.musicxml') as xml_fh, \
@@ -186,19 +185,19 @@ def render_musescore(part, fmt, out_fn=None, dpi=90):
             ps = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
             if ps.returncode != 0:
-                LOGGER.error(
+                warnings.warn(
                     "Command {} failed with code {}; stdout: {}; stderr: {}".format(
                         cmd,
                         ps.returncode,
                         ps.stdout.decode("UTF-8"),
                         ps.stderr.decode("UTF-8"),
-                    )
+                    ), SyntaxWarning, stacklevel=2
                 )
                 return None
 
         except FileNotFoundError as f:
 
-            LOGGER.error('Executing "{}" returned  {}.'.format(" ".join(cmd), f))
+            warnings.warn('Executing "{}" returned  {}.'.format(" ".join(cmd), f), ImportWarning, stacklevel=2)
             return None
 
         # LOGGER.error('Command "{}" returned with code {}; stdout: {}; stderr: {}'

--- a/partitura/musicanalysis/tonal_tension.py
+++ b/partitura/musicanalysis/tonal_tension.py
@@ -12,7 +12,7 @@ References
        Conference on Technologies for Music Notation and Representation
        (TENOR), Cambridge, UK.
 """
-import logging
+import warnings
 
 import numpy as np
 import scipy.spatial.distance as distance
@@ -22,8 +22,6 @@ from partitura.utils import get_time_units_from_note_array, ensure_notearray, ad
 
 
 __all__ = ["estimate_tonaltension"]
-
-LOGGER = logging.getLogger(__name__)
 
 # Scaling factors
 A = np.sqrt(2.0 / 15.0) * np.pi / 2.0
@@ -341,7 +339,7 @@ def prepare_note_array(note_info):
     key_signature_fields = ("ks_fifths", "ks_mode")
 
     if len(set(pitch_spelling_fields).difference(note_array.dtype.names)) > 0:
-        LOGGER.info("No pitch spelling information! Estimating pitch spelling...")
+        warnings.warn("No pitch spelling information! Estimating pitch spelling...", stacklevel=2)
         from partitura.musicanalysis.pitch_spelling import estimate_spelling
 
         spelling = estimate_spelling(note_array)
@@ -352,7 +350,7 @@ def prepare_note_array(note_info):
             note_array[field] = spelling[field]
 
     if len(set(key_signature_fields).difference(note_array.dtype.names)) > 0:
-        LOGGER.info("No key information! Estimating key...")
+        warnings.warn("No key information! Estimating key...", stacklevel=2)
         from partitura.musicanalysis.key_identification import estimate_key
         from partitura.utils.music import key_name_to_fifths_mode, key_mode_to_int
 
@@ -401,7 +399,7 @@ def key_map_from_keysignature(notearray, onset_unit="auto"):
             axis=0,
         )
         if len(ks) > 1:
-            LOGGER.warn(
+            warnings.warn(
                 "Multiple Key signtures detected at score position. "
                 "Taking the first one."
             )

--- a/partitura/performance.py
+++ b/partitura/performance.py
@@ -8,12 +8,10 @@ notes as well as continuous control parameters, such as sustain pedal.
 
 """
 
-import logging
+
 
 import numpy as np
 
-
-LOGGER = logging.getLogger(__name__)
 
 __all__ = ["PerformedPart"]
 

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -13,11 +13,10 @@ are registered in terms of their start and end times.
 from copy import copy
 from collections import defaultdict
 from collections.abc import Iterable
-import logging
 from numbers import Number
 # import copy
 from partitura.utils.music import MUSICAL_BEATS
-
+import warnings
 import numpy as np
 from scipy.interpolate import interp1d
 
@@ -43,7 +42,7 @@ from partitura.utils import (
     update_note_ids_after_unfolding,
 )
 
-LOGGER = logging.getLogger(__name__)
+
 
 
 class Part(object):
@@ -144,7 +143,7 @@ class Part(object):
         if len(tss) == 0:
             # default time sig
             beats, beat_type = 4, 4
-            LOGGER.warning(
+            warnings.warn(
                 "No time signatures found, assuming {}/{}".format(beats, beat_type)
             )
             if self.first_point is None:
@@ -189,7 +188,7 @@ class Part(object):
         if len(kss) == 0:
             # default key signature
             fifths, mode = 0, 1
-            LOGGER.warning("No key signature found, assuming C major")
+            warnings.warn("No key signature found, assuming C major")
             if self.first_point is None:
                 t0, tN = 0, 0
             else:
@@ -241,7 +240,7 @@ class Part(object):
 
         if len(measures) == 0:  # no measures in the piece
             # default only one measure spanning the entire timeline
-            LOGGER.warning("No measures found, assuming only one measure")
+            warnings.warn("No measures found, assuming only one measure")
             if self.first_point is None:
                 t0, tN = 0, 0
             else:
@@ -287,7 +286,7 @@ class Part(object):
 
         if len(measures) == 0:  # no measures in the piece
             # default only one measure spanning the entire timeline
-            LOGGER.warning("No measures found, assuming only one measure")
+            warnings.warn("No measures found, assuming only one measure")
             if self.first_point is None:
                 t0, tN = 0, 0
             else:
@@ -793,7 +792,7 @@ class Part(object):
 
         """
         if mode not in ("starting", "ending"):
-            LOGGER.warning('unknown mode "{}", using "starting" instead'.format(mode))
+            warnings.warn('unknown mode "{}", using "starting" instead'.format(mode))
             mode = "starting"
 
         if start is None:
@@ -1370,13 +1369,13 @@ class GenericNote(TimedObject):
         if self._sym_dur is None:
             # compute value
             if not self.start or not self.end:
-                LOGGER.warning(
+                warnings.warn(
                     "Cannot estimate symbolic duration for notes that "
                     "are not added to a Part"
                 )
                 return None
             if self.start.quarter is None:
-                LOGGER.warning(
+                warnings.warn(
                     "Cannot estimate symbolic duration when not "
                     "quarter_duration has been set. "
                     "See Part.set_quarter_duration."
@@ -1939,7 +1938,7 @@ class Tuplet(TimedObject):
                 if self.start_note and self.start_note.start:
                     self.start_note.start.remove_starting_object(self)
             # else:
-            #     LOGGER.warning('Note has no start time')
+            #     warnings.warn('Note has no start time')
             note.tuplet_starts.append(self)
         self._start_note = note
 
@@ -1956,7 +1955,7 @@ class Tuplet(TimedObject):
                     #  remove the tuplet from the currentend time
                     self.end_note.end.remove_ending_object(self)
             # else:
-            #     LOGGER.warning('Note has no end time')
+            #     warnings.warn('Note has no end time')
             note.tuplet_stops.append(self)
         self._end_note = note
 
@@ -2633,7 +2632,7 @@ def add_measures(part):
     )
 
     if len(timesigs) == 0:
-        LOGGER.warning("No time signatures found, not adding measures")
+        warnings.warn("No time signatures found, not adding measures")
         return
 
     start = part.first_point.t
@@ -3177,14 +3176,15 @@ def sanitize_part(part, tie_tolerance = 0):
                     tn.tie_next = None
                     tn.tie_prev = None
 
-    LOGGER.info(
+    warnings.warn(
         "part_sanitize removed {} incomplete tuplets, "
         "{} incomplete slurs, {} incomplete grace, "
         "and {} wrong ties."
         "notes".format(remove_tuplet_counter, 
                        remove_slur_counter, 
                        remove_grace_counter,
-                       remove_tie_counter)
+                       remove_tie_counter),
+        stacklevel=2
     )
 
 

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
-import logging
+import warnings
 from collections import defaultdict
 from textwrap import dedent
 import numpy as np
 
-LOGGER = logging.getLogger(__name__)
+
 
 __all__ = ["find_nearest", "iter_current_next", "partition", "iter_subclasses"]
 
@@ -233,7 +233,7 @@ class ReplaceRefMixin(object):
                         if o_el in o_map:
                             o_list_new.append(o_map[o_el])
                         else:
-                            LOGGER.warning(
+                            warnings.warn(
                                 dedent(
                                     """reference not found in
                             o_map: {} start={} end={}, substituting None
@@ -249,7 +249,7 @@ class ReplaceRefMixin(object):
                     if o in o_map:
                         o_new = o_map[o]
                     else:
-                        LOGGER.warning(
+                        warnings.warn(
                             dedent(
                                 """reference not found in o_map:
                         {} start={} end={}, substituting None

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python
 from collections import defaultdict
-import logging
 import re
-
+import warnings
 import numpy as np
 from scipy.interpolate import interp1d
 from scipy.sparse import csc_matrix
 
 from partitura.utils.generic import find_nearest, search, iter_current_next
-
-LOGGER = logging.getLogger(__name__)
 
 MIDI_BASE_CLASS = {"c": 0, "d": 2, "e": 4, "f": 5, "g": 7, "a": 9, "b": 11}
 # _MORPHETIC_BASE_CLASS = {'c': 0, 'd': 1, 'e': 2, 'f': 3, 'g': 4, 'a': 5, 'b': 6}
@@ -935,7 +932,7 @@ def compute_pianoroll(
         time_div = int(time_div)
 
     if "channel" in note_array.dtype.names and remove_drums:
-        LOGGER.info("Do not consider drum track for computing piano roll")
+        warnings.warn("Do not consider drum track for computing piano roll")
         non_drum_idxs = np.where(note_array["channel"] != 9)[0]
         note_array = note_array[non_drum_idxs]
 
@@ -1346,9 +1343,9 @@ def match_note_arrays(
             matched_target_idxs.append(taix[0])
     matched_idxs = np.array(matched_idxs)
 
-    LOGGER.info("Length of matched idxs: " "{0}".format(len(matched_idxs)))
-    LOGGER.info("Length of input note_array: " "{0}".format(len(input_note_array)))
-    LOGGER.info("Length of target note_array: " "{0}".format(len(target_note_array)))
+    warnings.warn("Length of matched idxs: " "{0}".format(len(matched_idxs)), stacklevel=2)
+    warnings.warn("Length of input note_array: " "{0}".format(len(input_note_array)), stacklevel=2)
+    warnings.warn("Length of target note_array: " "{0}".format(len(target_note_array)), stacklevel=2)
 
     if return_note_idxs:
         if len(matched_idxs) > 0:


### PR DESCRIPTION
Fixed warning inconsistencies by replacing all instances of ` loggings.LOGGER.warning` with `warnings.warn`.
Addressing issue #85 .
