### PR TITLE
add fast access properties to the part object

### DIFF
--- a/partitura/score.py
+++ b/partitura/score.py
@@ -507,6 +507,105 @@ class Part(object):
             for note in self.iter_all(Note, include_subclasses=True)
             if note.tie_prev is None
         ]
+        
+    @property
+    def measures(self):
+        """Return a list of all Measure objects in the part
+
+        Returns
+        -------
+        list
+            List of Measure objects
+
+        """
+        return [
+            e for e in self.iter_all(Measure, include_subclasses=False)
+        ]
+        
+    @property
+    def rests(self):
+        """Return a list of all rest objects in the part
+
+        Returns
+        -------
+        list
+            List of Rest objects
+
+        """
+        return [
+            e for e in self.iter_all(Rest, include_subclasses=False)
+        ]
+        
+    @property
+    def repeats(self):
+        """Return a list of all Repeat objects in the part
+
+        Returns
+        -------
+        list
+            List of Repeat objects
+
+        """
+        return [
+            e for e in self.iter_all(Repeat, include_subclasses=False)
+        ]
+
+    @property
+    def key_sigs(self):
+        """Return a list of all Key Signature objects in the part
+
+        Returns
+        -------
+        list
+            List of Key Signature objects
+
+        """
+        return [
+            e for e in self.iter_all(KeySignature, include_subclasses=False)
+        ]
+
+    @property
+    def time_sigs(self):
+        """Return a list of all Time Signature objects in the part
+
+        Returns
+        -------
+        list
+            List of Time Signature objects
+
+        """
+        return [
+            e for e in self.iter_all(TimeSignature, include_subclasses=False)
+        ]
+        
+    @property
+    def dynamics(self):
+        """Return a list of all Dynamics markings in the part
+
+        Returns
+        -------
+        list
+            List of Dynamics objects
+
+        """
+        return [
+            e for e in self.iter_all(LoudnessDirection, include_subclasses=True)
+        ]
+    
+    @property
+    def articulations(self):
+        """Return a list of all Articulation markings in the part
+
+        Returns
+        -------
+        list
+            List of Articulation objects
+
+        """
+        return [
+            e for e in self.iter_all(ArticulationDirection, include_subclasses=True)
+        ]
+        
 
     def quarter_durations(self, start=None, end=None):
         """Return an Nx2 array with quarter duration (second column)

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -3481,10 +3481,13 @@ def add_segments(part):
                             "to": [], 
                             "force_full_sequence": False,
                             "type": "default",
-                            "info": list()}
+                            "info": list(),
+                            "volta_numbers": list()}
         segment_info[boundary_times[-1]] = {"ID":"END"} 
         
         current_volta_repeat_start = 0
+        current_volta_end = 0
+        current_volta_total_number = 0
 
         for ss in boundary_times[:-1]:
             se = segment_info[ss]["end"]
@@ -3505,34 +3508,41 @@ def add_segments(part):
                 # VOLTA BRACKETS
                 if boundary_type == "volta_start":
                     if "volta_end" not in list(boundaries[se].keys()):
-                        bracket_end = se
-                        numbers = boundaries[bracket_end]["volta_start"].number.split(",")
-                        numbers = [str(int(n)) for n in numbers]
-                        for no in numbers:
-                            segment_info[ss]["to"].append(no+"_Volta_"+segment_info[se]["ID"])
+                        current_volta_total_number = 0
+                        current_volta_end = se
                         for volta_number in range(10): # maximal expected number of volta brackets 10
-                            if "volta_start" in list(boundaries[bracket_end].keys()):                 
+                            if "volta_start" in list(boundaries[current_volta_end].keys()):                 
                                 # add the beginning to the jump destinations
-                                numbers = boundaries[bracket_end]["volta_start"].number.split(",")
+                                numbers = boundaries[current_volta_end]["volta_start"].number.split(",")
                                 numbers = [str(int(n)) for n in numbers]
+                                current_volta_total_number += len(numbers)
                                 for no in numbers:
-                                    segment_info[ss]["to"].append(no+"_Volta_"+segment_info[bracket_end]["ID"])
+                                    segment_info[ss]["to"].append(no+"_Volta_"+segment_info[current_volta_end]["ID"])
+                                segment_info[current_volta_end]["info"].append("volta "+",".join(numbers))
+                                segment_info[current_volta_end]["volta_numbers"] += numbers
+                                # segment_info[bracket_end]["info"].append(str(len(numbers)))
                                 # update the search time to the end of the ext bracket
-                                bracket_end = boundaries[bracket_end]["volta_start"].end.t
+                                current_volta_end = boundaries[current_volta_end]["volta_start"].end.t
+                               
                     
                 if boundary_type == "volta_end":
-                    if "volta_start" in list(boundaries[se].keys()):
-                        # if repeating volta bracket, jump back to start
-                        # check if repeat exists (might not be for 3+ volta brackets)
-                        if "repeat_end" in list(boundaries[se].keys()):
-                            current_volta_repeat_start = max(boundaries[se]["repeat_end"].start.t,
-                                                             current_volta_repeat_start)
-                        repeat_start = current_volta_repeat_start
-                        segment_info[ss]["to"].append(segment_info[repeat_start]["ID"])
-                    else:
-                        # else just go to the next segment
-                        segment_info[ss]["to"].append(segment_info[se]["ID"])
-                    segment_info[ss]["info"].append("volta")
+                    current_volta_numbers = segment_info[ss]["volta_numbers"]
+                    for vn in current_volta_numbers: 
+                        if vn != str(current_volta_total_number):
+                            # if repeating volta bracket, jump back to start
+                            # check if repeat exists (might not be for 3+ volta brackets)
+                            if "repeat_end" in list(boundaries[se].keys()):
+                                current_volta_repeat_start = max(boundaries[se]["repeat_end"].start.t,
+                                                                current_volta_repeat_start)
+                            repeat_start = current_volta_repeat_start
+                            segment_info[ss]["to"].append(segment_info[repeat_start]["ID"])
+                        
+                    if str(current_volta_total_number) in current_volta_numbers:
+                        # else just go to the segment after the last
+                        segment_info[ss]["to"].append(segment_info[current_volta_end]["ID"])
+                    
+                    print("volta", segment_info[ss]["to"], current_volta_numbers, 
+                          current_volta_end, segment_info[current_volta_end]["ID"])    
                 
                 # NAVIGATION SYMBOLS
                 if boundary_type == "coda":
@@ -3589,17 +3599,26 @@ def add_segments(part):
                 # first segments is always a leap destination (da capo)
                 if ss == 0:
                     segment_info[ss]["type"] = "leap_end"
-                          
+        
+        
         for start_time in boundary_times[:-1]:
-            destinations = list(set(segment_info[start_time]["to"]))
-            destinations_no_volta = [dest for dest in destinations if "Volta_" not in dest]
-            destinations_volta = [dest for dest in destinations if "Volta_" in dest]
+            destinations = segment_info[start_time]["to"]
+            
+            print(destinations)
+            destinations_no_volta = [dest for dest in destinations 
+                                     if "Volta_" not in dest]
+            destinations_volta = [dest for dest in destinations 
+                                  if "Volta_" in dest]
+            
+            # make sure the "END" destination is the last
             if "END" in destinations:
-                destinations_no_volta.remove("END")
+                while "END" in destinations_no_volta:
+                    destinations_no_volta.remove("END")
                 destinations_no_volta.sort()
                 destinations_no_volta.append("END")
             else:
                 destinations_no_volta.sort()
+            # sort destinations by volta number
             destinations_volta.sort()
             # keep only the segment IDs
             destinations_volta = [d[8:] for d in destinations_volta]

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -2019,7 +2019,7 @@ def performance_from_part(part, bpm=100, velocity=64):
         ("channel", "i4"),
         ("id", "U256"),
     ]
-    snote_array = part.note_array
+    snote_array = part.note_array()
 
     pnote_array = np.zeros(len(snote_array), dtype=ppart_fields)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -34,9 +34,15 @@ MUSICXML_UNFOLD_TESTPAIRS = [
         )
     ]
 ]
+
 MUSICXML_UNFOLD_COMPLEX = [
     (os.path.join(MUSICXML_PATH, fn1), os.path.join(MUSICXML_PATH, fn2),)
     for fn1, fn2 in [("test_unfold_complex.xml", "test_unfold_complex_result.xml")]
+]
+
+MUSICXML_UNFOLD_VOLTA = [
+    (os.path.join(MUSICXML_PATH, fn1), os.path.join(MUSICXML_PATH, fn2),)
+    for fn1, fn2 in [("test_unfold_volta_numbers.xml", "test_unfold_volta_numbers_result.xml")]
 ]
 
 # This is a list of files for testing Chew and Wu's VOSA. (More files to come?)

--- a/tests/data/musicxml/test_unfold_volta_numbers.xml
+++ b/tests/data/musicxml/test_unfold_volta_numbers.xml
@@ -1,0 +1,163 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE score-partwise PUBLIC
+  "-//Recordare//DTD MusicXML 3.1 Partwise//EN"
+  "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <part-list>
+    <score-part id="P1">
+      <part-name>MusicXML Part</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1" width="365.85">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="77.22" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        <repeat direction="backward"/>
+        </barline>
+      </measure>
+    <measure number="2" width="176.75">
+      <note default-x="13.00" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="94.88" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="3" width="180.90">
+      <barline location="left">
+        <bar-style>heavy-light</bar-style>
+        <repeat direction="forward"/>
+        </barline>
+      <note default-x="31.85" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="4" width="288.91">
+      <note default-x="13.00" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="5" width="151.15">
+      <barline location="left">
+        <ending number="1, 4, 5" type="start" default-y="67.41"/>
+        </barline>
+      <note default-x="58.59" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        <ending number="1, 4, 5" type="stop"/>
+        <repeat direction="backward"/>
+        </barline>
+      </measure>
+    <measure number="6" width="152.22">
+      <barline location="left">
+        <ending number="2" type="start" default-y="67.41"/>
+        </barline>
+      <note>
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        </note>
+      <note default-x="81.71" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="7" width="151.27">
+      <note>
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        <ending number="2" type="stop"/>
+        <repeat direction="backward"/>
+        </barline>
+      </measure>
+    <measure number="8" width="146.15">
+      <barline location="left">
+        <ending number="3" type="start" default-y="67.41"/>
+        </barline>
+      <note default-x="13.96" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        <ending number="3" type="stop"/>
+        <repeat direction="backward"/>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/tests/data/musicxml/test_unfold_volta_numbers_result.xml
+++ b/tests/data/musicxml/test_unfold_volta_numbers_result.xml
@@ -1,0 +1,267 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE score-partwise PUBLIC
+  "-//Recordare//DTD MusicXML 3.1 Partwise//EN"
+  "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <part-list>
+    <score-part id="P1">
+      <part-name>MusicXML Part</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <!--=======================================================-->
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <staves>1</staves>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="1">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="5">
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="6">
+      <note>
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="7">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="8">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="5">
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="5">
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/tests/test_part_properties.py
+++ b/tests/test_part_properties.py
@@ -1,0 +1,33 @@
+import unittest
+import partitura
+from partitura import score
+
+
+class TestingPartProperties(unittest.TestCase):
+    def test_props(self):
+        part = score.Part("P0", "My Part")
+        part.set_quarter_duration(0, 10)
+        part.add(score.KeySignature(0, ""), start=0)
+        part.add(score.TimeSignature(3, 4), start=0)
+        part.add(score.TimeSignature(4, 4), start=30)
+        part.add(score.Note(id="n0", step="A", octave=4), start=0, end=10)
+        part.add(score.Rest(id="r0"), start=10, end=20)
+        part.add(score.Note(id="n1", step="A", octave=4), start=20, end=70)
+        part.add(score.ImpulsiveLoudnessDirection("sfz","sfz"), start=20, end=20)
+        part.add(score.ArticulationDirection("staccato","staccato"), start=0, end=0)
+        score.add_measures(part)
+        score.tie_notes(part)
+        
+        self.assertTrue(len(part.notes) == 3)
+        self.assertTrue(len(part.notes_tied) == 2)
+        self.assertTrue(len(part.measures) == 2)
+        self.assertTrue(len(part.time_sigs) == 2)
+        self.assertTrue(len(part.key_sigs) == 1)
+        self.assertTrue(len(part.rests) == 1)
+        self.assertTrue(len(part.articulations) == 1)
+        self.assertTrue(len(part.dynamics) == 1)
+        self.assertTrue(len(part.repeats) == 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -10,7 +10,8 @@ from tempfile import TemporaryFile
 
 from tests import ( MUSICXML_IMPORT_EXPORT_TESTFILES, 
                 MUSICXML_UNFOLD_TESTPAIRS,
-                MUSICXML_UNFOLD_COMPLEX )
+                MUSICXML_UNFOLD_COMPLEX,
+                MUSICXML_UNFOLD_VOLTA)
 
 from partitura import load_musicxml, save_musicxml
 from partitura.directions import parse_direction
@@ -113,8 +114,25 @@ class TestMusicXML(unittest.TestCase):
                 fn
             )
             self.assertTrue(equal, msg)
+            
+    def test_unfold_volta(self):
+        for fn, fn_target in MUSICXML_UNFOLD_VOLTA:
+            part = load_musicxml(fn, validate=False)
+            part = score.unfold_part_maximal(part)
+            # Load Target
+            with open(fn_target) as f:
+                target = f.read()
+            # Transform part to musicxml
+            result = save_musicxml(part).decode("UTF-8")
 
-        
+            equal = target == result
+            if not equal:
+                show_diff(result, target)
+            msg = "Unfolding volta part of MusicXML file {} does not yield expected result".format(
+                fn
+            )
+            self.assertTrue(equal, msg)
+
 
     def test_export_import_pprint(self):
         # create a part


### PR DESCRIPTION
added part properties for fast access (without having to use iter_all). The properties are called: measures, rests, repeats, dynamics, articulations, key_sigs, time_sigs. The follow the structure of notes and notes_tied, they return a list of objects.

The only unintuitive thing is that part.articulations returns part-level articulation directions only, text-based markings such as "staccato". Note-wise articulations such as a staccato dot (which are more common) are encoded as note attributes and not covered by this. To get these one has to use a note_array with articulation_feature from musicanalysis.note_features.