### PR TITLE
updated the chew voice separation

### DIFF
--- a/partitura/musicanalysis/voice_separation.py
+++ b/partitura/musicanalysis/voice_separation.py
@@ -67,7 +67,7 @@ def argmax_pitch(idx, pitches):
     return idx[np.argmax(pitches[idx])]
 
 
-def estimate_voices(note_info, monophonic_voices=False):
+def estimate_voices(note_info, monophonic_voices=True):
     """Voice estimation using the voice separation algorithm
        proposed in [6]_.
 
@@ -153,7 +153,10 @@ def estimate_voices(note_info, monophonic_voices=False):
     # occurring voice has number 2, etc.
     rvoices = rename_voices(voices)
 
-    return rvoices
+    # reverse voice numbers so that the high voices have the low numbers, like in musicxml
+    rrvoices = max(rvoices) - rvoices +1  
+
+    return rrvoices
 
 
 def pairwise_cost(prev, nxt):

--- a/tests/test_voice_estimation.py
+++ b/tests/test_voice_estimation.py
@@ -7,6 +7,7 @@ from tests import VOSA_TESTFILES
 
 from partitura import load_musicxml
 from partitura.musicanalysis import estimate_voices
+import partitura
 
 
 class TestVoSA(unittest.TestCase):
@@ -18,29 +19,32 @@ class TestVoSA(unittest.TestCase):
 
     def test_vosa_chew(self):
         # Example from Chew and Wu.
-        # notearray = musicxml_to_notearray(VOSA_TESTFILES[0], beat_times=False)
-        # voices = estimate_voices(self.score, monophonic_voices=True)
-        # # ground_truth_voices = np.array([3, 2, 1, 3, 3, 2, 3, 3, 2, 3,
-        # #                                 3, 1, 1, 2, 1, 1, 3, 2, 1, 1])
+        voices = estimate_voices(self.score, monophonic_voices=True)
+        # ground_truth_voices = np.array([3, 2, 1, 3, 3, 2, 3, 3, 2, 3,
+        #                                 3, 1, 1, 2, 1, 1, 3, 2, 1, 1])
         # ground_truth_voices = np.array(
         #     [1, 2, 3, 1, 1, 2, 1, 1, 2, 1, 1, 3, 3, 2, 3, 3, 1, 2, 3, 3]
         # )
-        # self.assertTrue(
-        #     np.all(voices == ground_truth_voices), "Incorrect voice assignment."
-        # )
+        ground_truth_voices = np.array(
+            [3, 2, 1, 1, 2, 1, 1, 2, 1, 1, 3, 1, 3, 3, 2, 3, 3, 2, 1, 3]
+        )
+        self.assertTrue(
+            np.all(voices == ground_truth_voices), "Incorrect voice assignment."
+        )
 
         self.assertTrue(True)
 
     def test_vosa_chew_chordnotes(self):
         # Example from Chew and Wu.
-        # notearray = musicxml_to_notearray(VOSA_TESTFILES[0], beat_times=False)
-
-        # voices = estimate_voices(self.score, monophonic_voices=False)
-        # print(voices)
+        voices = estimate_voices(self.score, monophonic_voices=False)
+        print(voices)
         # ground_truth_voices = np.array(
         #     [1, 2, 2, 1, 1, 2, 1, 1, 2, 1, 1, 2, 2, 3, 2, 2, 1, 1, 2, 2]
         # )
-        # self.assertTrue(
-        #     np.all(voices == ground_truth_voices), "Incorrect voice assignment."
-        # )
+        ground_truth_voices = np.array(
+            [3, 3, 2, 2, 3, 2, 2, 3, 2, 2, 3, 2, 3, 3, 1, 3, 3, 2, 2, 3]
+        )
+        self.assertTrue(
+            np.all(voices == ground_truth_voices), "Incorrect voice assignment."
+        )
         self.assertTrue(True)


### PR DESCRIPTION
I've updated the voice separation to produce voice numbers that are consistent with the typical usage in musicxml (i.e., lower voice numbers to higher notes) and updated the tests.

I've found that the trick we use to treat polyphonic notes generates very weird situations with voices being not in the correct order. For this reason, this option should be used with caution. I changed the default from polyphonic to monophonic, that is what Chew algorithm was made for.