### PR TITLE
51 move beat per measure from time signature to metrical position

### DIFF
--- a/partitura/io/exportmidi.py
+++ b/partitura/io/exportmidi.py
@@ -250,7 +250,7 @@ def save_score_midi(
         elif anacrusis_behavior == "pad_bar":
             time_signatures = []
             for qm, part in zip(quarter_maps, score.iter_parts(parts)):
-                ts_beats, ts_beat_type = part.time_signature_map(0)
+                ts_beats, ts_beat_type, ts_mus_beats = part.time_signature_map(0)
                 time_signatures.append((ts_beats, ts_beat_type, qm(0)))
             # sort ts according to time
             time_signatures.sort(key=lambda x: x[2])

--- a/partitura/musicanalysis/note_features.py
+++ b/partitura/musicanalysis/note_features.py
@@ -755,7 +755,7 @@ def metrical_feature(na, part):
 
     for i, n in enumerate(notes):
 
-        beats, beat_type = ts_map(n.start.t).astype(int)
+        beats, beat_type, mus_beats = ts_map(n.start.t).astype(int)
         measure = next(n.start.iter_prev(score.Measure, eq=True), None)
 
         if measure:
@@ -820,7 +820,7 @@ def time_signature_feature(na, part):
              ['time_signature_den_{0}'.format(b) for b in possible_beat_types])
 
     for i, n in enumerate(na):
-        beats, beat_type = ts_map(n["onset_div"]).astype(int)
+        beats, beat_type, mus_beats = ts_map(n["onset_div"]).astype(int)
 
         if beats in possible_beats:
             W_beats[i, beats - 1] = 1

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -133,9 +133,7 @@ class Part(object):
         """
         tss = np.array(
             [
-                (ts.start.t, ts.beats, ts.beat_type)
-                if self._use_musical_beat is False
-                else (ts.start.t, ts.musical_beats, ts.beat_type)
+                (ts.start.t, ts.beats, ts.beat_type, ts.musical_beats)
                 for ts in self.iter_all(TimeSignature)
             ]
         )
@@ -319,8 +317,7 @@ class Part(object):
         """
         measure_map = self.measure_map
         ms = [measure_map(m.start.t)[0] for m in self.iter_all(Measure)]
-        me = [measure_map(m.start.t)[1] for m in self.iter_all(Measure)]
-        
+        me = [measure_map(m.start.t)[1] for m in self.iter_all(Measure)]        
 
         if len(ms) < 2:
             warnings.warn("No or single measures found, metrical position 0 everywhere")

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -2121,7 +2121,7 @@ def note_array_from_note_list(
 
     # fields for time signature
     if time_signature_map is not None:
-        fields += [("ts_beats", "i4"), ("ts_beat_type", "i4")]
+        fields += [("ts_beats", "i4"), ("ts_beat_type", "i4"), ("ts_mus_beats", "i4")]
 
     # fields for metrical position
     if metrical_position_map is not None:
@@ -2183,9 +2183,9 @@ def note_array_from_note_list(
             note_info += (fifths, mode)
 
         if time_signature_map is not None:
-            beats, beat_type = time_signature_map(note.start.t)
+            beats, beat_type, mus_beats = time_signature_map(note.start.t)
 
-            note_info += (beats, beat_type)
+            note_info += (beats, beat_type, mus_beats)
 
         if metrical_position_map is not None:
             rel_onset_div, tot_measure_div = metrical_position_map(note.start.t)

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -1845,11 +1845,13 @@ def note_array_from_part(
         If `include_time_signature` is True:
             * 'ts_beats': number of beats in a measure
             * 'ts_beat_type': type of beats (denominator of the time signature)
+            * 'ts_mus_beat' : number of musical beats is it's set, otherwise ts_beats
 
         If `include_metrical_position` is True:
             * 'is_downbeat': 1 if the note onset is on a downbeat, 0 otherwise
             * 'rel_onset_div': number of divs elapsed from the beginning of the note measure
             * 'tot_measure_divs' : total number of divs in the note measure
+
         If 'include_grace_notes' is True:
             * 'is_grace': 1 if the note is a grace 0 otherwise
             * 'grace_type' : the type of the grace notes "" for non grace notes.

--- a/tests/test_note_array.py
+++ b/tests/test_note_array.py
@@ -77,7 +77,7 @@ class TestNoteArray(unittest.TestCase):
         part.use_musical_beat()
         note_array = note_array_from_part(part, include_time_signature=True)
         expected_musical_beats = [2, 2, 3, 3, 3, 4, 4, 4, 4, 2, 2, 2, 2]
-        self.assertTrue(np.array_equal(note_array["ts_beats"], expected_musical_beats))
+        self.assertTrue(np.array_equal(note_array["ts_mus_beats"], expected_musical_beats))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now time_signature map returns a triple:
(numerator, denominator, mus_beat_count)

This avoid confusion for people that wants to know the real numerator even if musical beat is set

