### PR TITLE
div unit flag in load_performance_midi

### DIFF
--- a/partitura/io/importkern.py
+++ b/partitura/io/importkern.py
@@ -516,7 +516,7 @@ class KernParser:
         match = re.findall(r"([0-9]+)([a-g]|[A-G]|r|\.)", kern_string)
         durs, _ = zip(*match)
         x = np.array(list(map(lambda x: int(x), durs)))
-        divs = np.lcm.reduce(np.unique(x))
+        divs = np.lcm.reduce(np.unique(x[x != 0]))
         return float(divs) / 4.00
 
 

--- a/partitura/io/importmidi.py
+++ b/partitura/io/importmidi.py
@@ -68,6 +68,7 @@ def load_performance_midi(
     filename: Union[PathLike, mido.MidiFile],
     default_bpm: Union[int, float] = 120,
     merge_tracks: bool = False,
+    time_in_divs: bool = False,
 ) -> performance.Performance:
     """Load a musical performance from a MIDI file.
 
@@ -111,7 +112,10 @@ def load_performance_midi(
     mpq = 60 * (10 ** 6 / default_bpm)
 
     # convert MIDI ticks in seconds
-    time_conversion_factor = mpq / (ppq * 10 ** 6)
+    if time_in_divs:
+        time_conversion_factor = 1
+    else:
+        time_conversion_factor = mpq / (ppq * 10 ** 6)
 
     notes = []
     controls = []
@@ -134,8 +138,11 @@ def load_performance_midi(
             if msg.type == "set_tempo":
 
                 mpq = msg.tempo
-
-                time_conversion_factor = mpq / (ppq * 10 ** 6)
+                
+                if time_in_divs:
+                    time_conversion_factor = 1
+                else:
+                    time_conversion_factor = mpq / (ppq * 10 ** 6)
 
                 warnings.warn(
                     (
@@ -225,7 +232,7 @@ def load_performance_midi(
         for i, note in enumerate(notes):
             note["id"] = f"n{i}"
 
-    pp = performance.PerformedPart(notes, controls=controls, programs=programs)
+    pp = performance.PerformedPart(notes, controls=controls, programs=programs, ppq = ppq)
 
     perf = performance.Performance(
         id=doc_name,

--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -347,6 +347,27 @@ def _parse_parts(document, part_dict):
                     "Single measure bracket is assumed"
                 )
 
+        # Complete repeats without end.
+        volta_repeats = list()
+        for o in part.iter_all(score.Repeat, mode="starting"):
+            if o.end is None:
+                # if len(o.start.starting_objects[score.Repeat]) > 0:
+                #     starting = list(o.start.starting_objects[score.Repeat].keys())[0]
+                #     # if unstarted repeat from volta, continue for now
+                #     if len(starting.end.ending_objects[score.Repeat]) > 0:
+                #         # if repeat from volta, continue for now
+                #         volta_repeats.append(o)
+                #         continue
+                
+                starting_repeats = [r for r in part.iter_all(score.Repeat) if r.start is not None] 
+                end_times = [r.start.t for r in starting_repeats] + [part._points[-1].t]
+                end_time_id = np.searchsorted(end_times, o.start.t+1)
+                part.add(o, None, end_times[end_time_id])
+                warnings.warn(
+                    "Found repeat without end\n"
+                    "Ending point {} is assumend".format(end_times[end_time_id])
+                )
+
         # complete unstarted repeats
         volta_repeats = list()
         for o in part.iter_all(score.Repeat, mode="ending"):

--- a/partitura/performance.py
+++ b/partitura/performance.py
@@ -73,6 +73,7 @@ class PerformedPart(object):
         controls: List[dict] = None,
         programs: List[dict] = None,
         sustain_pedal_threshold: int = 64,
+        ppq: int = 500
     ) -> None:
         super().__init__()
         self.id = id
@@ -80,6 +81,7 @@ class PerformedPart(object):
         self.notes = notes
         self.controls = controls or []
         self.programs = programs or []
+        self.ppq = ppq
 
         self.sustain_pedal_threshold = sustain_pedal_threshold
 

--- a/partitura/performance.py
+++ b/partitura/performance.py
@@ -48,6 +48,8 @@ class PerformedPart(object):
         The threshold above which sustain pedal values are considered
         to be equivalent to on. For values below the threshold the
         sustain pedal is treated as off. Defaults to 64.
+    ppq : int
+        Parts per Quarter (ppq) of the MIDI encoding. Defaults to 480. 
 
     Attributes
     ----------
@@ -73,7 +75,7 @@ class PerformedPart(object):
         controls: List[dict] = None,
         programs: List[dict] = None,
         sustain_pedal_threshold: int = 64,
-        ppq: int = 500
+        ppq: int = 480
     ) -> None:
         super().__init__()
         self.id = id

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -4587,12 +4587,12 @@ def merge_parts(parts, reassign="voice"):
     note_arrays = [part.note_array(include_staff=True) for part in parts]
     # find the maximum number of voices for each part (voice number start from 1)
     maximum_voices = [
-        max(note_array["voice"]) if max(note_array["voice"]) != 0 else 1
+        max(note_array["voice"], default=0) if max(note_array["voice"], default=0) != 0 else 1
         for note_array in note_arrays
     ]
     # find the maximum number of staves for each part (staff number start from 0 but we force them to 1)
     maximum_staves = [
-        max(note_array["staff"]) if max(note_array["staff"]) != 0 else 1
+        max(note_array["staff"], default=0) if max(note_array["staff"], default=0) != 0 else 1
         for note_array in note_arrays
     ]
 

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -1622,7 +1622,7 @@ def note_array_from_part_list(
 
     if is_score:
         # rescale if parts have different divs
-        divs_per_parts = [part[0]["divs_pq"] for part in note_array]
+        divs_per_parts = [part_na[0]["divs_pq"] for part_na in note_array if len(part_na)]
         lcm = np.lcm.reduce(divs_per_parts)
         time_multiplier_per_part = [int(lcm / d) for d in divs_per_parts]
         for na, time_mult in zip(note_array, time_multiplier_per_part):
@@ -2297,7 +2297,11 @@ def note_array_from_note_list(
 
     # Sanitize voice information
     no_voice_idx = np.where(note_array["voice"] == -1)[0]
-    max_voice = note_array["voice"].max()
+    try:
+        max_voice = note_array["voice"].max()
+    except ValueError:  # raised if `note_array["voice"]` is empty.
+        note_array["voice"] = 0
+        max_voice = 0
     note_array["voice"][no_voice_idx] = max_voice + 1
 
     # sort by onset and pitch

--- a/partitura/utils/synth.py
+++ b/partitura/utils/synth.py
@@ -71,12 +71,8 @@ def midi_pitch_to_natural_frequency(
     C4 is a descending major sixth with respect to A4, E5 is descending
     perfect fourth computed with respect to A5, etc.).
 
-
-    TODO
-    ----
-    * compute intervals with given reference pitch.
     """
-
+    
     octave = (midi_pitch // 12) - 1
 
     aref = 69.0 - 12.0 * (4 - octave)
@@ -96,6 +92,55 @@ def midi_pitch_to_natural_frequency(
     )
 
     freqs = aref_freq * ratios
+
+    if isinstance(midi_pitch, (int, float)):
+        freqs = float(freqs)
+    return freqs
+
+
+def midi_pitch_to_tempered_frequency(
+    midi_pitch: Union[int, float, np.ndarray],
+    reference_midi_pitch: Union[int, float] = 69,
+    reference_frequency: float = A4,
+    interval_ratios: Dict[int, float] = NATURAL_INTERVAL_RATIOS,
+) -> Union[float, np.ndarray]:
+    """
+    Convert MIDI pitch to frequency in Hz using 
+    a temperament given as frequency ratios above
+    a reference pitch.
+
+    Parameters
+    ----------
+    midi_pitch: int, float or ndarray
+        MIDI pitch of the note(s).
+    reference_midi_pitch : int or float (optional)
+        midi pitch of the reference pitch. By default is 69 (A4).
+    reference_frequency : int (optional)
+        Frequency of A4 in Hz. By default is 440 Hz.
+    interval_ratios: dict
+        Dictionary of interval ratios from the reference
+
+    Returns
+    -------
+    freq : float or ndarray
+        Frequency of the note(s).
+    """
+
+    interval = (midi_pitch - reference_midi_pitch) % 12
+    octave = (midi_pitch - reference_midi_pitch) // 12
+    adjusted_reference_frequency = reference_frequency / (2.0 ** -octave)
+
+    if isinstance(interval, (int, float)):
+        interval = np.array([interval], dtype=int)
+
+    ratios = np.array(
+        [
+            interval_ratios[abs(itv)]
+            for itv in interval
+        ]
+    )
+
+    freqs = adjusted_reference_frequency * ratios
 
     if isinstance(midi_pitch, (int, float)):
         freqs = float(freqs)

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -6,6 +6,7 @@ import tempfile
 
 from partitura.utils.synth import (
     midi_pitch_to_natural_frequency,
+    midi_pitch_to_tempered_frequency,
     exp_in_exp_out,
     lin_in_lin_out,
     additive_synthesis,
@@ -20,6 +21,21 @@ RNG = np.random.RandomState(1984)
 
 from tests import WAV_TESTFILES
 
+
+class TestMidiPitchToTemperedFrequency(unittest.TestCase):
+    def test_octaves(self):
+        # all As
+        midi_pitch = np.arange(6) + 10
+        freq_ratios = [1.1, 1.2, 1.3, 1.44, 1.5, 1.55]
+        # compute frequencies
+        frequency = midi_pitch_to_tempered_frequency(midi_pitch,
+                                                     reference_midi_pitch = 10,
+                                                     reference_frequency = 100,
+                                                     interval_ratios = freq_ratios)
+        freq_ratios_new = frequency / 100
+        # make test
+        self.assertTrue(np.allclose(freq_ratios, freq_ratios_new))
+        
 
 class TestMidiPitchToNaturalFrequency(unittest.TestCase):
     def test_octaves(self):


### PR DESCRIPTION
new flag to load performance midi files in midi div units. store their ppq values of midi files in performedparts. these changes don't affect other functionality (field names of note arrays are unchanged), but are sometimes useful for further preprocessing. 