### PR TITLE
Declare encoding and add/update docstrings at the top of each module

### DIFF
--- a/partitura/__init__.py
+++ b/partitura/__init__.py
@@ -1,7 +1,9 @@
-"""The top level of the package contains functions to load and save
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+The top level of the package contains functions to load and save
 data, display rendered scores, and functions to estimate pitch
 spelling, voice assignment, and key signature.
-
 """
 
 import pkg_resources

--- a/partitura/directions.py
+++ b/partitura/directions.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
 """
-Parse textual directions that occur in a score (in a MusicXML they are
-encoded as <words></words>), and if possible, convert them to a specific
-score.Direction class or subclass. For example "cresc." will produce a
-`score.DynamicLoudnessDirection` instance, and "Allegro molto" will produce a
-`score.ConstantTempoDirection` instance. If the meaning of the direction cannot
-be inferred, a `score.Words` instance is returned.
+This module contains methods to Parse textual directions that occur in a score
+(in a MusicXML they are encoded as <words></words>), and if possible, convert
+them to a specific score.Direction class or subclass. For example "cresc." will
+produce a `score.DynamicLoudnessDirection` instance, and "Allegro molto" will
+produce a `score.ConstantTempoDirection` instance. If the meaning of the
+direction cannot be inferred, a `score.Words` instance is returned.
 
 The functionality is provided by the function `parse_words`
 """

--- a/partitura/display.py
+++ b/partitura/display.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-
-"""This module defines a function "show" that creates a rendering of one
+# -*- coding: utf-8 -*-
+"""
+This module defines a function "show" that creates a rendering of one
 or more parts or partgroups and opens it using the desktop default
 application.
-
 """
 
 import platform

--- a/partitura/io/__init__.py
+++ b/partitura/io/__init__.py
@@ -1,3 +1,8 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+This module contains methods for importing and exporting symbolic music formats.
+"""
 from typing import Union
 
 from .importmusicxml import load_musicxml

--- a/partitura/io/exportaudio.py
+++ b/partitura/io/exportaudio.py
@@ -1,5 +1,8 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 """
-Synthesize Partitura object to wav using additive synthesis
+This module contains methods to synthesize Partitura object to wav using
+additive synthesis
 """
 from typing import Union, Optional
 import numpy as np

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -5,7 +5,7 @@ This module contains methods for exporting matchfiles
 """
 import numpy as np
 
-from typing import List, Optional, Union, Iterable
+from typing import List, Optional, Iterable
 from scipy.interpolate import interp1d
 
 from partitura.io.importmatch import (

--- a/partitura/io/exportmidi.py
+++ b/partitura/io/exportmidi.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
+"""
+This module contains methods for exporting MIDI files
+"""
 import numpy as np
 
 from collections import defaultdict, OrderedDict
-from typing import Union, Optional, Iterable
+from typing import Optional, Iterable
 
 from mido import MidiFile, MidiTrack, Message, MetaMessage
 

--- a/partitura/io/exportmusicxml.py
+++ b/partitura/io/exportmusicxml.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
+"""
+This module contains methods for exporting MusicXML files.
+"""
 import math
 from collections import defaultdict
 from lxml import etree

--- a/partitura/io/importkern.py
+++ b/partitura/io/importkern.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains methods for importing Humdrum Kern files.
+"""
 import re
 import warnings
 

--- a/partitura/io/importmei.py
+++ b/partitura/io/importmei.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains methods for importing MEI files.
+"""
 from lxml import etree
 from xmlschema.names import XML_NAMESPACE
 import partitura.score as score

--- a/partitura/io/importmidi.py
+++ b/partitura/io/importmidi.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains methods for importing MIDI files.
+"""
 import warnings
 
 from collections import defaultdict

--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
-
 # -*- coding: utf-8 -*-
+"""
+This module contains methods for importing MusicXML files.
+"""
 
 import os
 import warnings

--- a/partitura/io/importnakamura.py
+++ b/partitura/io/importnakamura.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 This module contains methods for parsing score-to-performance alignments

--- a/partitura/io/musescore.py
+++ b/partitura/io/musescore.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-
-"""This module contains functionality to use the MuseScore program as a
+# -*- coding: utf-8 -*-
+"""
+This module contains functionality to use the MuseScore program as a
 backend for loading and rendering scores.
-
 """
 
 import platform
@@ -23,7 +23,6 @@ from partitura.utils.misc import (
     deprecated_parameter,
     PathLike,
 )
-
 
 
 class MuseScoreNotFoundException(Exception):

--- a/partitura/musicanalysis/__init__.py
+++ b/partitura/musicanalysis/__init__.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Tools for music analysis.
-
+This module contains tools for estimating key signature, time signature,
+pitch spelling, voice information, tonal tension, as well as methods for
+deriving note-level features and performance encodings.
 """
 
 from .voice_separation import estimate_voices

--- a/partitura/musicanalysis/key_identification.py
+++ b/partitura/musicanalysis/key_identification.py
@@ -1,7 +1,12 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Krumhansl and Shepard key estimation
+This module implements Krumhansl and Schmuckler key estimation method.
 
+References
+----------
+.. [2] Krumhansl, Carol L. (1990) "Cognitive foundations of musical pitch",
+       Oxford University Press, New York.
 """
 import numpy as np
 from scipy.linalg import circulant

--- a/partitura/musicanalysis/meter.py
+++ b/partitura/musicanalysis/meter.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Meter numerator, Beat, and Tempo estimation.
+This module implements methods for Meter numerator, Beat, and Tempo estimation.
 
-Implementation adapted from Jakob Woegerbauer 
+Implementation adapted from Jakob Woegerbauer
 based on a model published by Simon Dixon.[1]
 
 References
 ----------
 
-.. [1] Simon Dixon (2001), Automatic extraction of 
+.. [1] Simon Dixon (2001), Automatic extraction of
     tempo and beat from expressive performances.
     Journal of New Music Research, 30(1):39–58
 """
 
 import warnings
 import numpy as np
+
 # import scipy.spatial.distance as distance
 # from scipy.interpolate import interp1d
 
@@ -26,24 +27,25 @@ from partitura.utils import get_time_units_from_note_array, ensure_notearray, ad
 MAX = 9999999999999
 MIN_INTERVAL = 0.01
 MAX_INTERVAL = 2  # in seconds
-CLUSTER_WIDTH = 1/12  # in seconds
+CLUSTER_WIDTH = 1 / 12  # in seconds
 N_CLUSTERS = 100
 INIT_DURATION = 10  # in seconds
 TIMEOUT = 10  # in seconds
 TOLERANCE_POST = 0.4  # propotion of beat_interval
 TOLERANCE_PRE = 0.2  # proportion of beat_interval
-TOLERANCE_INNER = 1/12 
-CORRECTION_FACTOR = 1/4  # higher => more correction (speed changes)
+TOLERANCE_INNER = 1 / 12
+CORRECTION_FACTOR = 1 / 4  # higher => more correction (speed changes)
 MAX_AGENTS = 100  # delete low-scoring agents when there are more than MAX_AGENTS
-CHORD_SPREAD_TIME = 1/12 # for onset aggregation
+CHORD_SPREAD_TIME = 1 / 12  # for onset aggregation
 
 
-class MultipleAgents():
+class MultipleAgents:
     """
     Class to compute inter onset interval clusters
-    and to instantiate a number of agents to 
+    and to instantiate a number of agents to
     approximate beat positions.
     """
+
     def run(self, onsets, salience):
         self.clusters = []
         self.agents = []
@@ -72,9 +74,9 @@ class MultipleAgents():
         # create inter-onset interval clusters
         self.clusters = []
         for i in range(len(onsets)):
-            for j in range(i+1, len(onsets)):
-                ioi = onsets[j]-onsets[i]
-                if ioi < MIN_INTERVAL: 
+            for j in range(i + 1, len(onsets)):
+                ioi = onsets[j] - onsets[i]
+                if ioi < MIN_INTERVAL:
                     continue
                 if ioi > MAX_INTERVAL:
                     break
@@ -92,7 +94,7 @@ class MultipleAgents():
         i = 0
         while i < len(self.clusters):
             c_i = self.clusters[i]
-            i = i+1
+            i = i + 1
             j = i
             while j < len(self.clusters):
                 if abs(c_i.interval - self.clusters[j].interval) < CLUSTER_WIDTH:
@@ -109,12 +111,12 @@ class MultipleAgents():
                 c.interval *= 2
             while c.interval > MAX_INTERVAL:
                 c.interval /= 2
-                
+
         # merge again
         i = 0
         while i < len(self.clusters):
             c_i = self.clusters[i]
-            i = i+1
+            i = i + 1
             j = i
             while j < len(self.clusters):
                 if abs(c_i.interval - self.clusters[j].interval) < CLUSTER_WIDTH:
@@ -127,11 +129,12 @@ class MultipleAgents():
         for c_i in self.clusters:
             for c_j in self.clusters:
                 n = round(c_j.interval / c_i.interval)
-                if abs(c_i.interval - n*c_j.interval) < CLUSTER_WIDTH:
+                if abs(c_i.interval - n * c_j.interval) < CLUSTER_WIDTH:
                     c_i.score += Cluster.relationship_factor(n) * len(c_j.iois)
 
         self.clusters = sorted(self.clusters, key=lambda x: x.score, reverse=True)[
-            :N_CLUSTERS]
+            :N_CLUSTERS
+        ]
 
     def init_tracking(self, onsets, salience):
         self.agents = []
@@ -146,7 +149,7 @@ class MultipleAgents():
                 self.agents.append(a)
                 i += 1
 
-    def track(self, onsets, salience):  
+    def track(self, onsets, salience):
         for e_i in range(len(onsets)):
             e = onsets[e_i]
             new_agents = []
@@ -155,10 +158,13 @@ class MultipleAgents():
                 if e - a.lastBeat() > TIMEOUT:
                     remove_agents.append(a)
                 else:
-                    while a.prediction + TOLERANCE_POST*a.beat_interval < e:
-                        a.history.append((a.prediction, 0)) 
+                    while a.prediction + TOLERANCE_POST * a.beat_interval < e:
+                        a.history.append((a.prediction, 0))
                         a.prediction += a.beat_interval
-                    if a.prediction - TOLERANCE_PRE*a.beat_interval <= e and e <= a.prediction + TOLERANCE_POST*a.beat_interval:
+                    if (
+                        a.prediction - TOLERANCE_PRE * a.beat_interval <= e
+                        and e <= a.prediction + TOLERANCE_POST * a.beat_interval
+                    ):
                         if abs(a.prediction - e) > TOLERANCE_INNER:
                             a_new = Agent()
                             a_new.beat_interval = a.beat_interval
@@ -167,10 +173,12 @@ class MultipleAgents():
                             a_new.score = a.score
                             new_agents.append(a_new)
                         err = e - a.prediction
-                        a.beat_interval = a.beat_interval + err*CORRECTION_FACTOR
+                        a.beat_interval = a.beat_interval + err * CORRECTION_FACTOR
                         a.prediction = e + a.beat_interval
                         a.history.append((e, salience[e_i]))
-                        a.score += (1-abs(err/a.beat_interval)/2.) * salience[e_i]
+                        a.score += (1 - abs(err / a.beat_interval) / 2.0) * salience[
+                            e_i
+                        ]
 
             for a in remove_agents:
                 self.agents.remove(a)
@@ -181,35 +189,42 @@ class MultipleAgents():
             agents_all = self.agents[:]
             self.agents = []
             for i in range(len(agents_all)):
-                for j in range(i+1, len(agents_all)):
+                for j in range(i + 1, len(agents_all)):
                     if duplicate[i] > 0 or duplicate[j] > 0:
                         continue
 
-                    if abs(agents_all[i].beat_interval - agents_all[j].beat_interval) < 0.01 \
-                            and abs(agents_all[i].lastBeat() - agents_all[j].lastBeat()) < 0.02:
+                    if (
+                        abs(agents_all[i].beat_interval - agents_all[j].beat_interval)
+                        < 0.01
+                        and abs(agents_all[i].lastBeat() - agents_all[j].lastBeat())
+                        < 0.02
+                    ):
                         if agents_all[i].score > agents_all[j].score:
                             duplicate[j] += 1
                         else:
                             duplicate[i] += 1
                             break
 
-            self.agents = sorted(np.asarray(agents_all)[(duplicate < 1)].tolist(
-            ), key=lambda x: x.score, reverse=True)[:MAX_AGENTS]
+            self.agents = sorted(
+                np.asarray(agents_all)[(duplicate < 1)].tolist(),
+                key=lambda x: x.score,
+                reverse=True,
+            )[:MAX_AGENTS]
 
         self.agents = sorted(self.agents, key=lambda x: x.score, reverse=True)
 
 
-class Cluster():
+class Cluster:
     """
     Class for inter onset interval clusters.
-    
+
     Parameters
     ----------
     ioi : float
-        an initial inter onset interval 
-    
+        an initial inter onset interval
+
     """
-    
+
     def __init__(self, ioi) -> None:
         self.iois = np.zeros(0)
         self.score = 0
@@ -217,24 +232,25 @@ class Cluster():
         self.addIoi(ioi)
 
     def getK(self, ioi):
-        diff = abs(self.interval-ioi)
+        diff = abs(self.interval - ioi)
         if diff < CLUSTER_WIDTH:
             return diff
         return False
 
     def addIoi(self, ioi):
         self.iois = np.append(self.iois, ioi)
-        self.interval = np.sum(self.iois)/len(self.iois)
+        self.interval = np.sum(self.iois) / len(self.iois)
 
     @staticmethod
     def relationship_factor(d):
         if 1 <= d and d <= 4:
-            return 6-d
+            return 6 - d
         elif 5 <= d and d <= 8:
             return 1
         return 0
 
-class Agent():
+
+class Agent:
     """
     Class for beat induction agents.
     """
@@ -246,43 +262,47 @@ class Agent():
         self.score = 0
 
     def lastBeat(self):
-        i = len(self.history)-1
+        i = len(self.history) - 1
         while i > 0 and self.history[i][1] == 0:
-            i-=1
+            i -= 1
         return self.history[i][0]
 
     def getTempo(self):
-        return 60.0 * (len(self.history)-1) / (self.history[-1][0]-self.history[0][0])
-    
+        return (
+            60.0 * (len(self.history) - 1) / (self.history[-1][0] - self.history[0][0])
+        )
+
     def getTimeSignatureNum(self):
         possibleNums = [2, 3, 4, 6, 9, 12, 24]
-        bestVal = {num:0 for num in possibleNums}
+        bestVal = {num: 0 for num in possibleNums}
         salience = list(zip(*self.history))[1]
         sumSalience = sum(salience)
         f = 1.005
         for num in possibleNums:
-            for startIdx in range(num):    
+            for startIdx in range(num):
                 dbs = len(salience[startIdx::num])
                 if dbs > 1:
-                    downbeatSalience = sum(salience[startIdx::num])/dbs
-                    sumSalience = sum(salience[:(dbs-1)*num]) 
-                    otherSalience = (sumSalience-downbeatSalience*dbs)/((num-1)*(dbs-1))
+                    downbeatSalience = sum(salience[startIdx::num]) / dbs
+                    sumSalience = sum(salience[: (dbs - 1) * num])
+                    otherSalience = (sumSalience - downbeatSalience * dbs) / (
+                        (num - 1) * (dbs - 1)
+                    )
                 else:
                     downbeatSalience = 0
                     otherSalience = 1
-                    
-                ratio = downbeatSalience/otherSalience
+
+                ratio = downbeatSalience / otherSalience
                 bestVal[num] = max(bestVal[num], ratio)
 
-        bestNum = max(bestVal, key=bestVal.get)    
-            
+        bestNum = max(bestVal, key=bestVal.get)
+
         return bestNum
 
 
 def estimate_time(note_info):
     """
     Estimate tempo, meter (currently only time signature numerator), and beats
-    
+
     Parameters
     ----------
     note_info : structured array, `Part` or `PerformedPart`
@@ -293,19 +313,19 @@ def estimate_time(note_info):
         onset and duration information of both score and performance,
         (e.g., containing both `onset_beat` and `onset_sec`), the score
         information will be preferred.
-    
+
     Returns
     -------
     dict
         Tempo, meter, and beat information
-    """         
+    """
 
     note_array = ensure_notearray(note_info)
     onset_kw, _ = get_time_units_from_note_array(note_array)
     onsets_raw = note_array[onset_kw]
-    
+
     # aggregate notes in clusters
-    aggregated_notes = [(0,0)]
+    aggregated_notes = [(0, 0)]
     for note_on in onsets_raw:
         prev_note_on = aggregated_notes[-1][0]
         prev_note_salience = aggregated_notes[-1][1]
@@ -313,14 +333,11 @@ def estimate_time(note_info):
             aggregated_notes[-1] = (note_on, prev_note_salience + 1)
         else:
             aggregated_notes.append((note_on, 1))
-        
-    print(aggregated_notes)    
+
+    print(aggregated_notes)
     onsets, saliences = list(zip(*aggregated_notes))
-    
+
     ma = MultipleAgents()
     ma.run(onsets, saliences)
-    
-    return dict(tempo=ma.getTempo(),
-                meter_numerator=ma.getNum(),
-                beats=ma.getBeats())
-    
+
+    return dict(tempo=ma.getTempo(), meter_numerator=ma.getNum(), beats=ma.getBeats())

--- a/partitura/musicanalysis/note_features.py
+++ b/partitura/musicanalysis/note_features.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains methods to compute note-level features.
+"""
 import sys
 import warnings
 import numpy as np

--- a/partitura/musicanalysis/performance_codec.py
+++ b/partitura/musicanalysis/performance_codec.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module implements a codec to encode and decode expressive performances to a set of
+expressive parameters.
+"""
 import numpy as np
 import numpy.lib.recfunctions as rfn
 try:

--- a/partitura/musicanalysis/pitch_spelling.py
+++ b/partitura/musicanalysis/pitch_spelling.py
@@ -1,11 +1,12 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Pitch Spelling using the ps13 algorithm.
+This module contains methods for estimation pitch spelling using the ps13 algorithm.
 
 References
 ----------
-
-
+.. [4] Meredith, D. (2006). "The ps13 Pitch Spelling Algorithm". Journal
+       of New Music Research, 35(2):121.
 """
 import numpy as np
 from collections import namedtuple

--- a/partitura/musicanalysis/tonal_tension.py
+++ b/partitura/musicanalysis/tonal_tension.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Spiral array representation and tonal tension profiles using Herreman and
-Chew's tension ribbons
+This module contains methods to compute Chew's  spiral array representation
+and the tonal tension profiles using Herreman and Chew's tension ribbons
 
 References
 ----------

--- a/partitura/musicanalysis/voice_separation.py
+++ b/partitura/musicanalysis/voice_separation.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Voice Separation using Chew and Wu's algorithm.
+"""
+This module contains methods for voice separation using Chew and Wu's algorithm.
 
+References
+----------
+.. [6] Chew, E. and Wu, Xiaodan (2004) "Separating Voices in
+       Polyphonic Music: A Contig Mapping Approach". In Uffe Kock,
+       editor, "Computer Music Modeling and Retrieval". Springer
+       Berlin Heidelberg.
 """
 from collections import defaultdict
 from statistics import mode

--- a/partitura/performance.py
+++ b/partitura/performance.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-"""This module contains a lightweight ontology to represent a performance in a
+"""
+This module contains a lightweight ontology to represent a performance in a
 MIDI-like format. A performance is defined at the highest level by a
 :class:`~partitura.performance.PerformedPart`. This object contains performed
 notes as well as continuous control parameters, such as sustain pedal.
-
 """
 
 

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -1,13 +1,12 @@
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
-
-
-"""This module defines an ontology of musical elements to represent
+"""
+This module defines an ontology of musical elements to represent
 musical scores, such as measures, notes, slurs, words, tempo and
 loudness directions. A score is defined at the highest level by a
 `Part` object (or a hierarchy of `Part` objects, in a `PartGroup`
 object). This object serves as a timeline at which musical elements
 are registered in terms of their start and end times.
-
 """
 
 from copy import copy

--- a/partitura/utils/__init__.py
+++ b/partitura/utils/__init__.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Top level of the utilities module.
+"""
 
 from partitura.utils.generic import (
     ComparableMixin,
@@ -51,7 +55,7 @@ from partitura.utils.synth import (
     synthesize
 )
 
-from .misc import (
+from partitura.utils.misc import (
     PathLike,
     get_document_name,
     deprecated_alias,
@@ -72,4 +76,5 @@ __all__ = [
     "pitch_spelling_to_note_name",
     "show_diff",
     "PrettyPrintTree",
+    "synthesize",
 ]

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -1,5 +1,8 @@
-#!/usr/bin/env python
-
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+This module contains generic class- and numerical-related utilities
+"""
 import warnings
 from collections import defaultdict
 from textwrap import dedent

--- a/partitura/utils/misc.py
+++ b/partitura/utils/misc.py
@@ -1,3 +1,8 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+This module contains miscellaneous utilities.
+"""
 import functools
 import os
 import warnings

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains music related utilities
+"""
 from collections import defaultdict
 import re
 import warnings

--- a/partitura/utils/synth.py
+++ b/partitura/utils/synth.py
@@ -1,9 +1,12 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 """
-Synthesize Partitura Part or Note array to wav using additive synthesis
+This module contains methods for synthesizing score- or performance-like
+objects using additive synthesis
 
 TODO
+----
 * Add other tuning systems?
-
 """
 from typing import Union, Tuple, Dict, Optional, Any, Callable
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
-# encoding: utf-8
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # pylint: skip-file
 """
 This module contains tests.

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module includes tests for deprecation utilities.
+"""
 import unittest
 import warnings
 import numpy as np

--- a/tests/test_kern.py
+++ b/tests/test_kern.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
-This file contains test functions for KERN import and export.
+This module contains test functions for KERN import and export.
 """
 import unittest
 
@@ -32,14 +34,14 @@ class TestImportKERN(unittest.TestCase):
         for fn in KERN_TESTFILES:
             part = merge_parts(load_kern(fn))
             ka = ensure_notearray(part)
-            self.assertTrue(True == True)
+            self.assertTrue(True)
 
     def test_tie_mismatch(self):
 
         fn = KERN_TIES[0]
         part = merge_parts(load_kern(fn))
 
-        self.assertTrue(True == True)
+        self.assertTrue(True)
 
 
 # if __name__ == "__main__":

--- a/tests/test_key_estimation.py
+++ b/tests/test_key_estimation.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for the key estimation methods.
+"""
 import unittest
 
 from partitura import EXAMPLE_MUSICXML

--- a/tests/test_load_performance.py
+++ b/tests/test_load_performance.py
@@ -1,7 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
-
-This file contains test functions for the load_performance method
-
+This module contains test functions for the `load_performance` method
 """
 import unittest
 
@@ -10,7 +10,7 @@ from tests import MATCH_IMPORT_EXPORT_TESTFILES
 
 from partitura import load_performance, EXAMPLE_MIDI
 from partitura.io import NotSupportedFormatError
-from partitura.performance import PerformedPart, Performance
+from partitura.performance import Performance
 
 
 class TestLoadScore(unittest.TestCase):

--- a/tests/test_load_score.py
+++ b/tests/test_load_score.py
@@ -1,7 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
-
-This file contains test functions for the load_score method
-
+This module contains test functions for the `load_score` method.
 """
 import unittest
 

--- a/tests/test_mei.py
+++ b/tests/test_mei.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
-This file contains test functions for MEI export
+This module contains test functions for MEI export
 """
 
 import unittest

--- a/tests/test_merge_parts.py
+++ b/tests/test_merge_parts.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for the utilities for merging parts.
+"""
 import numpy as np
 import logging
 import unittest

--- a/tests/test_metrical_position.py
+++ b/tests/test_metrical_position.py
@@ -1,7 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
-
-This file contains test functions for the metrical position computation
-
+This module contains test functions for the metrical position computation
 """
 
 import unittest

--- a/tests/test_midi_export.py
+++ b/tests/test_midi_export.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
+"""
+This module cotains tests for exporting MIDI file methods.
+"""
 import logging
 from collections import defaultdict, Counter, OrderedDict
 import unittest

--- a/tests/test_midi_import.py
+++ b/tests/test_midi_import.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for importing MIDI files.
+"""
 import logging
 from collections import defaultdict, Counter
 from operator import itemgetter

--- a/tests/test_nakamura.py
+++ b/tests/test_nakamura.py
@@ -1,8 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
-
-This file contains test functions for the import of Nakamura et al.'s match and
+This module contains test functions for the import of Nakamura et al.'s match and
 corresp file formats.
-
 """
 
 import unittest

--- a/tests/test_new_divs.py
+++ b/tests/test_new_divs.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for methods for handling divisions and time signatures.
+"""
 import logging
 import unittest
 

--- a/tests/test_note_array.py
+++ b/tests/test_note_array.py
@@ -1,7 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 This module contains the test cases for testing the note_array attribute of
 the Part class.
-
 """
 
 import unittest

--- a/tests/test_note_features.py
+++ b/tests/test_note_features.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for methods for generating note-level features.
+"""
 import unittest
 from tests import (
     METRICAL_POSITION_TESTFILES,

--- a/tests/test_parangonada.py
+++ b/tests/test_parangonada.py
@@ -1,7 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
-
-This file contains test functions for MusicXML import and export.
-
+This module contains test functions for Parangonada import and export.
 """
 
 import logging

--- a/tests/test_part_properties.py
+++ b/tests/test_part_properties.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for part properties.
+"""
 import unittest
 import partitura
 from partitura import score

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,7 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
-
-This file contains test functions for the `performance` module
-
+This module contains test functions for the `performance` module
 """
 import unittest
 import numpy as np

--- a/tests/test_performance_codec.py
+++ b/tests/test_performance_codec.py
@@ -1,7 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
-
-This file contains test functions for Performance Array Calculations
-
+This module contains test functions for Performance Array Calculations
 """
 import unittest
 import numpy as np

--- a/tests/test_pianoroll.py
+++ b/tests/test_pianoroll.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for methods for computing piano rolls.
+"""
 import numpy as np
 import logging
 import unittest

--- a/tests/test_pitch_spelling.py
+++ b/tests/test_pitch_spelling.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for the pitch spelling algorithms.
+"""
 import numpy as np
 import unittest
 

--- a/tests/test_quarter_adjust.py
+++ b/tests/test_quarter_adjust.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for adjusting quarter durations
+"""
 
 import logging
 import unittest

--- a/tests/test_rest_array.py
+++ b/tests/test_rest_array.py
@@ -1,7 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 This module contains the test cases for testing the note_array attribute of
 the Part class.
-
 """
 
 import unittest

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for the synthesis methods.
+"""
 import unittest
 
 import numpy as np
@@ -17,9 +22,9 @@ from partitura import EXAMPLE_MUSICXML, load_score
 
 from partitura import save_wav
 
-RNG = np.random.RandomState(1984)
-
 from tests import WAV_TESTFILES
+
+RNG = np.random.RandomState(1984)
 
 
 class TestMidiPitchToTemperedFrequency(unittest.TestCase):
@@ -28,14 +33,16 @@ class TestMidiPitchToTemperedFrequency(unittest.TestCase):
         midi_pitch = np.arange(6) + 10
         freq_ratios = [1.1, 1.2, 1.3, 1.44, 1.5, 1.55]
         # compute frequencies
-        frequency = midi_pitch_to_tempered_frequency(midi_pitch,
-                                                     reference_midi_pitch = 10,
-                                                     reference_frequency = 100,
-                                                     interval_ratios = freq_ratios)
+        frequency = midi_pitch_to_tempered_frequency(
+            midi_pitch,
+            reference_midi_pitch=10,
+            reference_frequency=100,
+            interval_ratios=freq_ratios,
+        )
         freq_ratios_new = frequency / 100
         # make test
         self.assertTrue(np.allclose(freq_ratios, freq_ratios_new))
-        
+
 
 class TestMidiPitchToNaturalFrequency(unittest.TestCase):
     def test_octaves(self):

--- a/tests/test_time_estimation.py
+++ b/tests/test_time_estimation.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for the methods for estimating metrical information.
+"""
 import numpy as np
 
 import unittest

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for testing conversions from beats and quarters.
+"""
 import unittest
 
 import partitura.score as score

--- a/tests/test_tonal_tension.py
+++ b/tests/test_tonal_tension.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for the methods computing tonal tension.
+"""
 import unittest
 
 from partitura import (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for the utility methods.
+"""
 import unittest
 import partitura
 import numpy as np

--- a/tests/test_voice_estimation.py
+++ b/tests/test_voice_estimation.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for the voice estimation methods.
+"""
 import numpy as np
 
 import unittest

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1,7 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
-
-This file contains test functions for MusicXML import and export.
-
+This module contains test functions for MusicXML import and export.
 """
 
 import logging


### PR DESCRIPTION
This pull request contains the following changes:

* Consistently define python source code encoding (as utf-8) following [PEP263](https://peps.python.org/pep-0263/) in all files
* Added docstrings at the top of all files (and unify the formatting in the existing ones)
* Fix test loading matchfiles
* Minor cosmetic changes:
    * Blacken files
    * Remove some unused imports

This pull request fixes issue #157.