### PR TITLE
fix issues #184 and #185

### DIFF
--- a/partitura/score.py
+++ b/partitura/score.py
@@ -18,7 +18,7 @@ from numbers import Number
 from partitura.utils.music import MUSICAL_BEATS
 import warnings
 import numpy as np
-from scipy.interpolate import interp1d, PPoly
+from scipy.interpolate import PPoly
 from typing import Union, List, Optional, Iterator, Iterable as Itertype
 
 from partitura.utils import (
@@ -44,6 +44,8 @@ from partitura.utils import (
     _OrderedSet,
     update_note_ids_after_unfolding,
 )
+
+from partitura.utils.generic import interp1d
 
 
 class Part(object):
@@ -201,9 +203,6 @@ class Part(object):
 
             kss = np.array([(t0, fifths, mode), (tN, fifths, mode)])
 
-        elif len(kss) == 1:
-            # if there is only a single key signature
-            return lambda x: np.array([kss[0, 1], kss[0, 2]])
         elif kss[0, 0] > self.first_point.t:
             kss = np.vstack(((self.first_point.t, kss[0, 1], kss[0, 2]), kss))
 
@@ -259,12 +258,10 @@ class Part(object):
             kind="previous",
             axis=0,
             fill_value="extrapolate",
+            dtype=int,
         )
 
-        def int_interp1d(input):
-            return inter_function(input).astype(int)
-
-        return int_interp1d
+        return inter_function
 
     @property
     def measure_number_map(self):
@@ -314,13 +311,14 @@ class Part(object):
             measures = np.array([(t0, tN, 1)])
 
         inter_function = interp1d(
-            measures[:, 0], measures[:, 2], kind="previous", fill_value="extrapolate"
+            measures[:, 0],
+            measures[:, 2],
+            kind="previous",
+            fill_value="extrapolate",
+            dtype=int,
         )
 
-        def int_interp1d(input):
-            return inter_function(input).astype(int)
-
-        return int_interp1d
+        return inter_function
 
     @property
     def metrical_position_map(self):
@@ -346,12 +344,10 @@ class Part(object):
                 axis=0,
                 kind="linear",
                 fill_value="extrapolate",
+                dtype=int,
             )
 
-            def zero_fun(input):
-                return zero_interpolator(input).astype(int)
-
-            return zero_fun
+            return zero_interpolator
         else:
             barlines = np.array(ms + me[-1:])
             bar_durations = np.diff(barlines)
@@ -2495,7 +2491,7 @@ class Tempo(TimedObject):
 
         """
         return int(
-            np.round(60 * (10 ** 6 / to_quarter_tempo(self.unit or "q", self.bpm)))
+            np.round(60 * (10**6 / to_quarter_tempo(self.unit or "q", self.bpm)))
         )
 
     def __str__(self):
@@ -2944,6 +2940,7 @@ class Score(object):
             include_key_signature=include_key_signature,
             include_time_signature=include_time_signature,
             include_grace_notes=include_grace_notes,
+            include_metrical_position=include_metrical_position,
             include_staff=include_staff,
             include_divs_per_quarter=include_divs_per_quarter,
             **kwargs,
@@ -4586,12 +4583,16 @@ def merge_parts(parts, reassign="voice"):
     note_arrays = [part.note_array(include_staff=True) for part in parts]
     # find the maximum number of voices for each part (voice number start from 1)
     maximum_voices = [
-        max(note_array["voice"], default=0) if max(note_array["voice"], default=0) != 0 else 1
+        max(note_array["voice"], default=0)
+        if max(note_array["voice"], default=0) != 0
+        else 1
         for note_array in note_arrays
     ]
     # find the maximum number of staves for each part (staff number start from 0 but we force them to 1)
     maximum_staves = [
-        max(note_array["staff"], default=0) if max(note_array["staff"], default=0) != 0 else 1
+        max(note_array["staff"], default=0)
+        if max(note_array["staff"], default=0) != 0
+        else 1
         for note_array in note_arrays
     ]
 

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -548,6 +548,13 @@ def interp1d(
     assume_sorted : bool, optional
         If False, values of `x` can be in any order and they are sorted first.
         If True, `x` has to be an array of monotonically increasing values.
+
+    Returns
+    -------
+    interp_fun : callable
+        The interpolator instance. This method takes an input array, float
+        or integer and returns an array with the specified dtype (if `dtype`
+        is not None).
     """
     if len(x) > 1:
         interp_fun = sc_interp1d(

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -5,8 +5,12 @@ This module contains generic class- and numerical-related utilities
 """
 import warnings
 from collections import defaultdict
+
+from typing import Union, Callable, Optional
+
 from textwrap import dedent
 import numpy as np
+from scipy.interpolate import interp1d as sc_interp1d
 
 
 __all__ = ["find_nearest", "iter_current_next", "partition", "iter_subclasses"]
@@ -470,6 +474,123 @@ def search(states, success, expand, combine):
             return state
         else:
             states = combine(expand(state), states)
+
+
+def interp1d(
+    x: np.ndarray,
+    y: np.ndarray,
+    dtype: Optional[type] = None,
+    axis: int = -1,
+    kind: Union[str, int] = "linear",
+    copy=True,
+    bounds_error=None,
+    fill_value=np.nan,
+    assume_sorted=False,
+) -> Callable:
+    """
+    Interpolate a 1-D function using scipy's interp1d method. This utility allows for
+    handling the case where `x` and `y` are only a single value (i.e. have length one,
+    which results in a ValueError if using scipy's version directly). It also allows for
+    specifying the dtype of the output.
+
+    `x` and `y` are arrays of values used to approximate some function f:
+    ``y = f(x)``. This class returns a function whose call method uses
+    interpolation to find the value of new points.
+
+    The description of the parameters has been taken from `scipy.interpolate.interp1d`.
+
+    Parameters
+    ----------
+    x : (N,) array_like
+        A 1-D array of real values.
+    y : (...,N,...) array_like
+        A N-D array of real values. The length of `y` along the interpolation
+        axis must be equal to the length of `x`.
+    dtype : type, optional
+        Type of the output array (e.g.,  `float`, `int`). By default it is set to
+        None (i.e., the array will have the same type as the outputs from
+        scipy's interp1d method.
+    axis : int, optional
+        Specifies the axis of `y` along which to interpolate.
+        Interpolation defaults to the last axis of `y`.
+    kind : str or int, optional
+        Specifies the kind of interpolation as a string or as an integer
+        specifying the order of the spline interpolator to use.
+        The string has to be one of 'linear', 'nearest', 'nearest-up', 'zero',
+        'slinear', 'quadratic', 'cubic', 'previous', or 'next'. 'zero',
+        'slinear', 'quadratic' and 'cubic' refer to a spline interpolation of
+        zeroth, first, second or third order; 'previous' and 'next' simply
+        return the previous or next value of the point; 'nearest-up' and
+        'nearest' differ when interpolating half-integers (e.g. 0.5, 1.5)
+        in that 'nearest-up' rounds up and 'nearest' rounds down. Default
+        is 'linear'.
+    copy : bool, optional
+        If True, the class makes internal copies of x and y.
+        If False, references to `x` and `y` are used. The default is to copy.
+    bounds_error : bool, optional
+        If True, a ValueError is raised any time interpolation is attempted on
+        a value outside of the range of x (where extrapolation is
+        necessary). If False, out of bounds values are assigned `fill_value`.
+        By default, an error is raised unless ``fill_value="extrapolate"``.
+    fill_value : array-like or (array-like, array_like) or "extrapolate", optional
+        - if a ndarray (or float), this value will be used to fill in for
+          requested points outside of the data range. If not provided, then
+          the default is NaN. The array-like must broadcast properly to the
+          dimensions of the non-interpolation axes.
+        - If a two-element tuple, then the first element is used as a
+          fill value for ``x_new < x[0]`` and the second element is used for
+          ``x_new > x[-1]``. Anything that is not a 2-element tuple (e.g.,
+          list or ndarray, regardless of shape) is taken to be a single
+          array-like argument meant to be used for both bounds as
+          ``below, above = fill_value, fill_value``.
+        - If "extrapolate", then points outside the data range will be
+          extrapolated.
+    assume_sorted : bool, optional
+        If False, values of `x` can be in any order and they are sorted first.
+        If True, `x` has to be an array of monotonically increasing values.
+    """
+    if len(x) > 1:
+        interp_fun = sc_interp1d(
+            x=x,
+            y=y,
+            kind=kind,
+            axis=axis,
+            copy=copy,
+            bounds_error=bounds_error,
+            fill_value=fill_value,
+            assume_sorted=assume_sorted,
+        )
+
+    else:
+
+        # If there is only one value for x and y, assume that the method
+        # will always return the same value for any input.
+
+        def interp_fun(
+            input_var: Union[float, int, np.ndarray]
+        ) -> Callable[[Union[float, int, np.ndarray]], np.ndarray]:
+
+            if y.ndim > 1:
+                result = np.broadcast_to(y, (len(np.atleast_1d(input_var)), y.shape[1]))
+            else:
+                result = np.broadcast_to(y, (len(np.atleast_1d(input_var)),))
+
+            if not isinstance(input_var, np.ndarray):
+                # the output of scipy's interp1d is always an array
+                result = np.array(result[0])
+
+            return result
+
+    if dtype is not None:
+
+        def typed_interp(
+            input_var: Union[float, int, np.ndarray]
+        ) -> Callable[[Union[float, int, np.ndarray]], np.ndarray]:
+            return interp_fun(input_var).astype(dtype)
+
+        return typed_interp
+    else:
+        return interp_fun
 
 
 # def search_recursive(states, success, expand, combine):

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -486,24 +486,25 @@ def interp1d(
     bounds_error=None,
     fill_value=np.nan,
     assume_sorted=False,
-) -> Callable:
+) -> Callable[[Union[float, int, np.ndarray]], np.ndarray]:
     """
     Interpolate a 1-D function using scipy's interp1d method. This utility allows for
     handling the case where `x` and `y` are only a single value (i.e. have length one,
     which results in a ValueError if using scipy's version directly). It also allows for
     specifying the dtype of the output.
 
+    The description of the parameters has been taken from `scipy.interpolate.interp1d`.
+
     `x` and `y` are arrays of values used to approximate some function f:
     ``y = f(x)``. This class returns a function whose call method uses
     interpolation to find the value of new points.
 
-    The description of the parameters has been taken from `scipy.interpolate.interp1d`.
 
     Parameters
     ----------
-    x : (N,) array_like
+    x : (N,) np.ndarray
         A 1-D array of real values.
-    y : (...,N,...) array_like
+    y : (...,N,...) np.ndarray
         A N-D array of real values. The length of `y` along the interpolation
         axis must be equal to the length of `x`.
     dtype : type, optional

--- a/tests/test_note_array.py
+++ b/tests/test_note_array.py
@@ -8,7 +8,7 @@ the Part class.
 import unittest
 
 import partitura.score as score
-from partitura import load_musicxml, load_kern
+from partitura import load_musicxml, load_kern, load_score
 from partitura.utils.music import note_array_from_part, ensure_notearray
 import numpy as np
 
@@ -95,6 +95,58 @@ class TestNoteArray(unittest.TestCase):
             self.assertTrue(note["onset_div"] == 92)
             self.assertTrue(note["duration_div"] == 4)
             self.assertTrue(note["divs_pq"] == 4)
+
+    def test_score_notearray_method(self):
+        """
+        Test that note array generated from the Score class method
+        include all relevant information.
+        """
+
+        for fn in NOTE_ARRAY_TESTFILES:
+
+            scr = load_score(fn)
+
+            na = scr.note_array(
+                include_pitch_spelling=True,
+                include_key_signature=True,
+                include_time_signature=True,
+                include_grace_notes=True,
+                include_metrical_position=True,
+                include_staff=True,
+                include_divs_per_quarter=True,
+            )
+
+            expected_field_names = [
+                "onset_beat",
+                "duration_beat",
+                "onset_quarter",
+                "duration_quarter",
+                "onset_div",
+                "duration_div",
+                "pitch",
+                "voice",
+                "id",
+                "step",
+                "alter",
+                "octave",
+                "is_grace",
+                "grace_type",
+                "ks_fifths",
+                "ks_mode",
+                "ts_beats",
+                "ts_beat_type",
+                "ts_mus_beats",
+                "is_downbeat",
+                "rel_onset_div",
+                "tot_measure_div",
+                "staff",
+                "divs_pq",
+            ]
+
+            for field_name in expected_field_names:
+                # check that the note array contain the relevant
+                # field.
+                self.assertTrue(field_name in na.dtype.names)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request addresses the following issues:

* It closes issue #184 (missing metrical information when generating note arrays from `Score` instances)

* It closes issue #185. Since the issue with scipy's `interp1d` also affects other time maps, this pull request adds a drop-in replacement for Scipy's `interp1d` method in `partitura.utils.generic`. This utility has the same interface/arguments as inter1d, but it also allows for creating an interpolation with inputs of length 1. For example

```python
import numpy as np
from scipy.interpolate import interp1d
int_fun = interp1d(x=np.array([1]), y=np.array([2]))
```

will result in `ValueError: x and y arrays must have at least 2 entries`. 

The new interpolation utility solves issues generating time maps for `Part` objects (e.g., `measure_map`) when there is only a relevant object (e.g., measures for `mesure_map`, key signatures for `key_signature_map`, etc.) defined in the `Part` instance.  Furthermore, the utility also allows for specifying the output dtype of the array, which is relevant for time maps where the output is expected to be an integer. This pull request also includes updates in the relevant time maps in `Part`, which now use the `intper1d` replacement from `partitura.utils.generic`.