### PR TITLE
Midi tick

### DIFF
--- a/partitura/io/importmidi.py
+++ b/partitura/io/importmidi.py
@@ -128,7 +128,7 @@ def load_performance_midi(
     for i, track in tracks:
 
         t = 0
-        tdiv = 0
+        ttick = 0
         
         sounding_notes = {}
 
@@ -136,7 +136,7 @@ def load_performance_midi(
 
             # update time deltas when they arrive
             t = t + msg.time * time_conversion_factor
-            tdiv = tdiv + msg.time 
+            ttick = ttick + msg.time 
 
             if msg.type == "set_tempo":
 
@@ -148,7 +148,7 @@ def load_performance_midi(
                 controls.append(
                     dict(
                         time=t,
-                        time_div=tdiv,
+                        time_tick=ttick,
                         number=msg.control,
                         value=msg.value,
                         track=i,
@@ -161,7 +161,7 @@ def load_performance_midi(
                 programs.append(
                     dict(
                         time=t,
-                        time_div=tdiv,
+                        time_tick=ttick,
                         program=msg.program,
                         track=i,
                         channel=msg.channel,
@@ -183,7 +183,7 @@ def load_performance_midi(
                 if note_on and msg.velocity > 0:
 
                     # save the onset time and velocity
-                    sounding_notes[note] = (t, tdiv, msg.velocity)
+                    sounding_notes[note] = (t, ttick, msg.velocity)
 
                 # end note if it's a 'note off' event or 'note on' with velocity 0
                 elif note_off or (note_on and msg.velocity == 0):
@@ -199,9 +199,9 @@ def load_performance_midi(
                             # id=f"n{len(notes)}",
                             midi_pitch=msg.note,
                             note_on=(sounding_notes[note][0]),
-                            note_on_div=(sounding_notes[note][1]),
+                            note_on_tick=(sounding_notes[note][1]),
                             note_off=(t),
-                            note_off_div=(tdiv),
+                            note_off_tick=(ttick),
                             track=i,
                             channel=msg.channel,
                             velocity=sounding_notes[note][2],

--- a/partitura/io/importmidi.py
+++ b/partitura/io/importmidi.py
@@ -71,8 +71,7 @@ def midi_to_notearray(filename: PathLike) -> np.ndarray:
 def load_performance_midi(
     filename: Union[PathLike, mido.MidiFile],
     default_bpm: Union[int, float] = 120,
-    merge_tracks: bool = False,
-    time_in_divs: bool = False,
+    merge_tracks: bool = False
 ) -> performance.Performance:
     """Load a musical performance from a MIDI file.
 
@@ -116,10 +115,7 @@ def load_performance_midi(
     mpq = 60 * (10 ** 6 / default_bpm)
 
     # convert MIDI ticks in seconds
-    if time_in_divs:
-        time_conversion_factor = 1
-    else:
-        time_conversion_factor = mpq / (ppq * 10 ** 6)
+    time_conversion_factor = mpq / (ppq * 10 ** 6)
 
     notes = []
     controls = []
@@ -132,35 +128,27 @@ def load_performance_midi(
     for i, track in tracks:
 
         t = 0
+        tdiv = 0
+        
         sounding_notes = {}
 
         for msg in track:
 
             # update time deltas when they arrive
             t = t + msg.time * time_conversion_factor
+            tdiv = tdiv + msg.time 
 
             if msg.type == "set_tempo":
 
                 mpq = msg.tempo
-                
-                if time_in_divs:
-                    time_conversion_factor = 1
-                else:
-                    time_conversion_factor = mpq / (ppq * 10 ** 6)
-
-                warnings.warn(
-                    (
-                        "change of Tempo to mpq = {0} "
-                        " and resulting seconds per tick = {1}"
-                        "at time: {2}"
-                    ).format(mpq, time_conversion_factor, t)
-                )
+                time_conversion_factor = mpq / (ppq * 10 ** 6)
 
             elif msg.type == "control_change":
 
                 controls.append(
                     dict(
                         time=t,
+                        time_div=tdiv,
                         number=msg.control,
                         value=msg.value,
                         track=i,
@@ -173,6 +161,7 @@ def load_performance_midi(
                 programs.append(
                     dict(
                         time=t,
+                        time_div=tdiv,
                         program=msg.program,
                         track=i,
                         channel=msg.channel,
@@ -194,7 +183,7 @@ def load_performance_midi(
                 if note_on and msg.velocity > 0:
 
                     # save the onset time and velocity
-                    sounding_notes[note] = (t, msg.velocity)
+                    sounding_notes[note] = (t, tdiv, msg.velocity)
 
                 # end note if it's a 'note off' event or 'note on' with velocity 0
                 elif note_off or (note_on and msg.velocity == 0):
@@ -210,13 +199,14 @@ def load_performance_midi(
                             # id=f"n{len(notes)}",
                             midi_pitch=msg.note,
                             note_on=(sounding_notes[note][0]),
+                            note_on_div=(sounding_notes[note][1]),
                             note_off=(t),
+                            note_off_div=(tdiv),
                             track=i,
                             channel=msg.channel,
-                            velocity=sounding_notes[note][1],
+                            velocity=sounding_notes[note][2],
                         )
                     )
-
                     # remove hash from dict
                     del sounding_notes[note]
 

--- a/partitura/performance.py
+++ b/partitura/performance.py
@@ -140,8 +140,8 @@ class PerformedPart(object):
         fields = [
             ("onset_sec", "f4"),
             ("duration_sec", "f4"),
-            ("onset_div", "i4"),
-            ("duration_div", "i4"),
+            ("onset_tick", "i4"),
+            ("duration_tick", "i4"),
             ("pitch", "i4"),
             ("velocity", "i4"),
             ("track", "i4"),
@@ -151,16 +151,16 @@ class PerformedPart(object):
         note_array = []
         for n in self.notes:
             note_on_sec = n["note_on"]
-            note_on_div = n["note_on_div"]
+            note_on_tick = n.get("note_on_tick", n["note_on"])
             offset = n.get("sound_off", n["note_off"])
             duration_sec = offset - note_on_sec
-            duration_div = n["note_off_div"] - note_on_div
+            duration_tick = n.get("note_off_tick", n["note_off"]) - note_on_tick
             note_array.append(
                 (
                     note_on_sec,
                     duration_sec,
-                    note_on_div,
-                    duration_div,
+                    note_on_tick,
+                    duration_tick,
                     n["midi_pitch"],
                     n["velocity"],
                     n.get("track", 0),

--- a/partitura/performance.py
+++ b/partitura/performance.py
@@ -108,10 +108,13 @@ class PerformedPart(object):
 
     @sustain_pedal_threshold.setter
     def sustain_pedal_threshold(self, value: int) -> None:
-        # """
-        # Set the pedal threshold and update the sound_off
-        # of the notes
-        # """
+        """
+        Set the pedal threshold and update the sound_off
+        of the notes. The threshold is a MIDI CC value 
+        between 0 and 127. The higher the threshold, the 
+        more restrained the pedal use and the drier the 
+        performance. Set to 127 to deactivate pedal.
+        """
         self._sustain_pedal_threshold = value
         adjust_offsets_w_sustain(
             self.notes, self.controls, self._sustain_pedal_threshold
@@ -137,6 +140,8 @@ class PerformedPart(object):
         fields = [
             ("onset_sec", "f4"),
             ("duration_sec", "f4"),
+            ("onset_div", "i4"),
+            ("duration_div", "i4"),
             ("pitch", "i4"),
             ("velocity", "i4"),
             ("track", "i4"),
@@ -146,12 +151,16 @@ class PerformedPart(object):
         note_array = []
         for n in self.notes:
             note_on_sec = n["note_on"]
+            note_on_div = n["note_on_div"]
             offset = n.get("sound_off", n["note_off"])
             duration_sec = offset - note_on_sec
+            duration_div = n["note_off_div"] - note_on_div
             note_array.append(
                 (
                     note_on_sec,
                     duration_sec,
+                    note_on_div,
+                    duration_div,
                     n["midi_pitch"],
                     n["velocity"],
                     n.get("track", 0),

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -363,8 +363,8 @@ def get_time_units_from_note_array(note_array):
     if fields is None:
         raise ValueError("`note_array` must be a structured numpy array")
 
-    score_units = set(("onset_beat", "onset_quarter",))
-    performance_units = set(("onset_sec",))
+    score_units = set(("onset_beat", "onset_quarter","onset_div"))
+    performance_units = set(("onset_sec","onset_tick"))
 
     if len(score_units.intersection(fields)) > 0:
         if "onset_beat" in fields:
@@ -376,8 +376,8 @@ def get_time_units_from_note_array(note_array):
     elif len(performance_units.intersection(fields)) > 0:
         if "onset_sec" in fields:
             return ("onset_sec", "duration_sec")
-        elif "onset_div" in fields:
-            return ("onset_div", "duration_div")
+        elif "onset_tick" in fields:
+            return ("onset_tick", "duration_tick")
         
     else:
         raise ValueError("Input array does not contain the expected " "time-units")

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -363,7 +363,7 @@ def get_time_units_from_note_array(note_array):
     if fields is None:
         raise ValueError("`note_array` must be a structured numpy array")
 
-    score_units = set(("onset_beat", "onset_quarter", "onset_div"))
+    score_units = set(("onset_beat", "onset_quarter",))
     performance_units = set(("onset_sec",))
 
     if len(score_units.intersection(fields)) > 0:
@@ -374,7 +374,11 @@ def get_time_units_from_note_array(note_array):
         elif "onset_div" in fields:
             return ("onset_div", "duration_div")
     elif len(performance_units.intersection(fields)) > 0:
-        return ("onset_sec", "duration_sec")
+        if "onset_sec" in fields:
+            return ("onset_sec", "duration_sec")
+        elif "onset_div" in fields:
+            return ("onset_div", "duration_div")
+        
     else:
         raise ValueError("Input array does not contain the expected " "time-units")
 

--- a/tests/test_load_performance.py
+++ b/tests/test_load_performance.py
@@ -32,5 +32,4 @@ class TestLoadPerformance(unittest.TestCase):
 
 
 if __name__ == "__main__":
-
     unittest.main()

--- a/tests/test_load_performance.py
+++ b/tests/test_load_performance.py
@@ -26,7 +26,7 @@ class TestLoadPerformance(unittest.TestCase):
         for fn in [EXAMPLE_MIDI]:
             performance = load_performance_midi(fn)
             na = performance.note_array()            
-            self.assertTrue(np.all(na["onset_sec"] * 24 == na["onset_div"]))
+            self.assertTrue(np.all(na["onset_sec"] * 24 == na["onset_tick"]))
         
 
 

--- a/tests/test_load_performance.py
+++ b/tests/test_load_performance.py
@@ -4,23 +4,33 @@
 This module contains test functions for the `load_performance` method
 """
 import unittest
+import numpy as np
+from tests import MOZART_VARIATION_FILES
 
-from tests import MATCH_IMPORT_EXPORT_TESTFILES
 
-
-from partitura import load_performance, EXAMPLE_MIDI
+from partitura import load_performance_midi, EXAMPLE_MIDI
 from partitura.io import NotSupportedFormatError
 from partitura.performance import Performance
 
-
-class TestLoadScore(unittest.TestCase):
+class TestLoadPerformance(unittest.TestCase):
     def test_load_performance(self):
-        for fn in MATCH_IMPORT_EXPORT_TESTFILES + [EXAMPLE_MIDI]:
-            load_performance(fn)
+        for fn in [MOZART_VARIATION_FILES["midi"]] + [EXAMPLE_MIDI]:
+            try:
+                print(fn)
+                performance = load_performance_midi(fn)
+                self.assertTrue(isinstance(performance, Performance))
+            except NotSupportedFormatError:
+                self.assertTrue(False)
 
-    def load_performance(self, fn):
-        try:
-            performance = load_performance(fn)
-            self.assertTrue(isinstance(performance, Performance))
-        except NotSupportedFormatError:
-            self.assertTrue(False)
+    def test_array_performance(self):
+        for fn in [EXAMPLE_MIDI]:
+            performance = load_performance_midi(fn)
+            na = performance.note_array()            
+            self.assertTrue(np.all(na["onset_sec"] * 24 == na["onset_div"]))
+        
+
+
+
+if __name__ == "__main__":
+
+    unittest.main()


### PR DESCRIPTION
adds new fields  ```onset_div``` and  ```duration_div``` to  ```PerformedPart.note_array()``` and the corresponding load functionality to ```load_performance_midi()```. The time unit is MIDI divs / ticks as loaded from the MIDI file directly.