### PR TITLE
Fix bug exporting Match Files

### DIFF
--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -291,12 +291,12 @@ def matchfile_from_alignment(
 
             ts_num, ts_den, _ = spart.time_signature_map(snote.start.t)
 
-            duration_symb = Fraction(duration_divs, int(ts_den) * dpq)
+            duration_symb = Fraction(duration_divs, dpq * 4)
 
             beat = int((onset_divs - msd) // dpq)
 
             moffset_divs = Fraction(
-                int(onset_divs - msd - beat * dpq), (int(ts_den) * dpq)
+                int(onset_divs - msd - beat * dpq), (dpq * 4)
             )
 
             if debug:

--- a/partitura/io/importmatch.py
+++ b/partitura/io/importmatch.py
@@ -69,6 +69,7 @@ from partitura.io.matchfile_utils import (
     number_pattern,
     MatchTimeSignature,
     MatchKeySignature,
+    format_pnote_id,
 )
 
 from partitura.utils.music import (
@@ -97,7 +98,7 @@ def get_version(line: str) -> Version:
     """
     Get version from the first line. Since the
     first version of the format did not include this line,
-    we assume that the version is 0.1.0 if no version is 
+    we assume that the version is 0.1.0 if no version is
     found.
 
     Parameters
@@ -288,7 +289,7 @@ def note_alignment_from_matchfile(mf: MatchFile) -> List[dict]:
                 dict(
                     label="match",
                     score_id=str(line.snote.Anchor),
-                    performance_id=str(line.note.Id),
+                    performance_id=format_pnote_id(line.note.Id),
                 )
             )
 
@@ -304,7 +305,9 @@ def note_alignment_from_matchfile(mf: MatchFile) -> List[dict]:
             line,
             BaseInsertionLine,
         ):
-            result.append(dict(label="insertion", performance_id=str(line.note.Id)))
+            result.append(
+                dict(label="insertion", performance_id=format_pnote_id(line.note.Id))
+            )
         elif isinstance(line, BaseOrnamentLine):
             if isinstance(line, MatchTrillNoteV0):
                 ornament_type = "trill"
@@ -316,7 +319,7 @@ def note_alignment_from_matchfile(mf: MatchFile) -> List[dict]:
                 dict(
                     label="ornament",
                     score_id=str(line.Anchor),
-                    performance_id=str(line.note.Id),
+                    performance_id=format_pnote_id(line.note.Id),
                     type=ornament_type,
                 )
             )
@@ -370,7 +373,7 @@ def performed_part_from_match(
 
     notes = [
         dict(
-            id=note.Id,
+            id=format_pnote_id(note.Id),
             midi_pitch=note.MidiPitch,
             note_on=midi_ticks_to_seconds(note.Onset, mpq, ppq) - offset,
             note_off=midi_ticks_to_seconds(note.Offset, mpq, ppq) - offset,

--- a/partitura/io/matchfile_utils.py
+++ b/partitura/io/matchfile_utils.py
@@ -602,6 +602,13 @@ def format_accidental_old(value: Optional[int]) -> str:
         return format_accidental(value)
 
 
+def format_pnote_id(value: Any) -> str:
+
+    pnote_id = f"n{str(value)}" if not str(value).startswith("n") else str(value)
+
+    return pnote_id
+
+
 ## Methods for parsing special attributes
 
 


### PR DESCRIPTION
This pull request addresses two small bugs:

* The symbolic duration of the notes was computed incorrectly and gave wrong results for time signatures where the denominator is not a quarter (e.g., 6/8)
* Ensure that performance information loaded from match files include an "n" at the beginning of performed note ids. At the moment, the inclusion of the "n" was only guaranteed in (newly) exported match files, and in `PerformedPart` objects from MIDI files, but it was missing when loading alignments from older match file versions