### PR TITLE
Closes #261 "none" mode for key signature.

### DIFF
--- a/partitura/io/matchfile_utils.py
+++ b/partitura/io/matchfile_utils.py
@@ -655,7 +655,7 @@ class MatchKeySignature(MatchParameter):
             component.fmt = fmt
 
     def fifths_mode_to_key_name_v0_1_0(self, fifths: int, mode: str) -> str:
-        if mode == "major":
+        if mode in ("major", None, "none", 1):
             keylist = MAJOR_KEYS
             suffix = "major"
         elif mode == "minor":
@@ -670,7 +670,7 @@ class MatchKeySignature(MatchParameter):
         return ks
 
     def fifths_mode_to_key_name_v0_3_0(self, fifths: int, mode: str) -> str:
-        if mode == "major":
+        if mode in ("major", None, "none", 1):
             keylist = MAJOR_KEYS
             suffix = "Maj"
         elif mode == "minor":

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -729,7 +729,7 @@ def fifths_mode_to_key_name(fifths, mode=None):
     if mode in ("minor", -1):
         keylist = MINOR_KEYS
         suffix = "m"
-    elif mode in ("major", None, 1):
+    elif mode in ("major", None, "none", 1):
         keylist = MAJOR_KEYS
         suffix = ""
     else:


### PR DESCRIPTION
Simple fix for `mode=='none'`.