### PR TITLE
mei measure number is now an integer, and. Measure.name is the string…

### DIFF
--- a/partitura/io/importmei.py
+++ b/partitura/io/importmei.py
@@ -956,7 +956,7 @@ class MeiParser(object):
             The created partitura part object.
         measure_number : int
             The number of the measure. This number is independent of the measure name specified in the score.
-            It starts from 0 and always increases by 1 at each measure
+            It starts from 1 and always increases by 1 at each measure
 
         Returns
         -------
@@ -1036,7 +1036,7 @@ class MeiParser(object):
         position : int
             The end position of the section.
         """
-        measure_number = 0
+        measure_number = 1
         for i_el, element in enumerate(section_el):
             # handle measures
             if element.tag == self._ns_name("measure"):

--- a/partitura/io/importmei.py
+++ b/partitura/io/importmei.py
@@ -940,7 +940,7 @@ class MeiParser(object):
             position = new_position
         return position
 
-    def _handle_staff_in_measure(self, staff_el, staff_ind, position: int, part):
+    def _handle_staff_in_measure(self, staff_el, staff_ind, position: int, part: pt.score.Part, measure_number: int):
         """
         Handles staffs inside a measure element.
 
@@ -954,6 +954,9 @@ class MeiParser(object):
             The current position on the timeline.
         part : Partitura.Part
             The created partitura part object.
+        measure_number : int
+            The number of the measure. This number is independent of the measure name specified in the score.
+            It starts from 0 and always increases by 1 at each measure
 
         Returns
         -------
@@ -961,7 +964,7 @@ class MeiParser(object):
             The final position on the timeline.
         """
         # add measure
-        measure = score.Measure(number=staff_el.getparent().get("n"))
+        measure = score.Measure(number=measure_number,name=staff_el.getparent().get("n"))
         part.add(measure, position)
 
         layers_el = staff_el.findall(self._ns_name("layer"))
@@ -1033,6 +1036,7 @@ class MeiParser(object):
         position : int
             The end position of the section.
         """
+        measure_number = 0
         for i_el, element in enumerate(section_el):
             # handle measures
             if element.tag == self._ns_name("measure"):
@@ -1045,7 +1049,7 @@ class MeiParser(object):
                 end_positions = []
                 for i_s, (part, staff_el) in enumerate(zip(parts, staves_el)):
                     end_positions.append(
-                        self._handle_staff_in_measure(staff_el, i_s + 1, position, part)
+                        self._handle_staff_in_measure(staff_el, i_s + 1, position, part, measure_number)
                     )
                 # handle directives (dir elements)
                 self._handle_directives(element, position)
@@ -1067,6 +1071,7 @@ class MeiParser(object):
                 position = max_position
                 # handle right barline symbol
                 self._handle_barline_symbols(element, position, "right")
+                measure_number += 1
             # handle staffDef elements
             elif element.tag == self._ns_name("scoreDef"):
                 # meter modifications

--- a/tests/test_mei.py
+++ b/tests/test_mei.py
@@ -291,8 +291,8 @@ class TestImportMEI(unittest.TestCase):
         onsets = score.note_array()["onset_div"]
         measure_number_per_each_onset = measure_number_map(onsets)
         self.assertTrue(measure_number_per_each_onset[0].dtype == int)
-        self.assertTrue(min(measure_number_per_each_onset) == 0)
-        self.assertTrue(max(measure_number_per_each_onset) == 33)
+        self.assertTrue(min(measure_number_per_each_onset) == 1)
+        self.assertTrue(max(measure_number_per_each_onset) == 34)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mei.py
+++ b/tests/test_mei.py
@@ -294,5 +294,11 @@ class TestImportMEI(unittest.TestCase):
         self.assertTrue(min(measure_number_per_each_onset) == 1)
         self.assertTrue(max(measure_number_per_each_onset) == 34)
 
+    def test_measure_number2(self):
+        score = load_mei(MEI_TESTFILES[13])
+        measure_number_map = score.parts[0].measure_number_map
+        measure_number_per_each_onset = measure_number_map(score.note_array()["onset_div"])
+        self.assertTrue(measure_number_per_each_onset.tolist()==[1,2,2,3,4,5,6,8])
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mei.py
+++ b/tests/test_mei.py
@@ -285,5 +285,14 @@ class TestImportMEI(unittest.TestCase):
         score = load_mei(MEI_TESTFILES[17])
         self.assertTrue(np.array_equal(score.note_array()["duration_div"],[3,3,3,3,3,3,3,3,24]))
 
+    def test_measure_number(self):
+        score = load_mei(MEI_TESTFILES[0])
+        measure_number_map = score.parts[0].measure_number_map
+        onsets = score.note_array()["onset_div"]
+        measure_number_per_each_onset = measure_number_map(onsets)
+        self.assertTrue(measure_number_per_each_onset[0].dtype == int)
+        self.assertTrue(min(measure_number_per_each_onset) == 0)
+        self.assertTrue(max(measure_number_per_each_onset) == 33)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixed a problem with Measure elements in MEI loading.
Now measure has 2 attributes:
- number: an integer, from 0, which increase at each measure
- name: the string how is encoded by the person writing the score (it may start from 1 or have strings inside)