### PR TITLE
solution for empty dynamic directions.

### DIFF
--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -842,10 +842,8 @@ def _handle_direction(e, position, part, ongoing):
             # dynamics items, so we loop:
             for child in direction_type:
                 # check if child has no children, in which case continue
-                if len(child) == 0:
-                    continue
                 # interpret as score.Direction, fall back to score.Words
-                dyn_el = next(iter(child))
+                dyn_el = next(iter(child), None)
                 if dyn_el is not None:
                     direction = DYN_DIRECTIONS.get(dyn_el.tag, score.Words)(
                         dyn_el.tag, staff=staff

--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -841,6 +841,9 @@ def _handle_direction(e, position, part, ongoing):
             # first child of direction-type is dynamics, there may be subsequent
             # dynamics items, so we loop:
             for child in direction_type:
+                # check if child has no children, in which case continue
+                if len(child) == 0:
+                    continue
                 # interpret as score.Direction, fall back to score.Words
                 dyn_el = next(iter(child))
                 if dyn_el is not None:

--- a/tests/data/musicxml/test_note_features.xml
+++ b/tests/data/musicxml/test_note_features.xml
@@ -84,6 +84,14 @@
           <line>2</line>
           </clef>
         </attributes>
+      <direction placement="below">
+        <direction-type>
+          <dynamics>
+          </dynamics>
+        </direction-type>
+        <staff>1</staff>
+        <sound dynamics="100.00"/>
+      </direction>
       <note default-x="80.72" default-y="-30.00">
         <pitch>
           <step>G</step>


### PR DESCRIPTION
This PR is a fix for a minor musicxml import bug that occurs when empty dynamics directions are encountered.