### PR TITLE
bug fix for nakamura match file parsing

### DIFF
--- a/partitura/io/importnakamura.py
+++ b/partitura/io/importnakamura.py
@@ -149,7 +149,7 @@ def load_nakamuramatch(filename: PathLike) -> Tuple[Union[np.ndarray, list]]:
     missing = np.fromregex(filename, pattern, dtype=dtype_missing)
 
     midi_pitch = np.array(
-        [note_name_to_midi_pitch(n.replace("#", r"\#")) for n in result["alignSitch"]]
+        [note_name_to_midi_pitch(n) for n in result["alignSitch"]]
     )
 
     align_valid = result["alignID"] != "*"


### PR DESCRIPTION
remove unnecessary escape character for correct parsing of sharp accidentals in nakamura match files.