### PR TITLE
Bug fix 326

### DIFF
--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -358,7 +358,7 @@ def matchfile_from_alignment(
                 offset_in_beats=offset_beats,
                 score_attributes_list=score_attributes_list,
             )
-            snote_sort_info[snote.id] = (onset_beats, snote.doc_order)
+            snote_sort_info[snote.id] = (onset_beats, snote.doc_order if snote.doc_order is not None else 0)
 
     # # NOTE time position is hardcoded, not pretty...  Assumes there is only one tempo indication at the beginning of the score
     if tempo_indication is not None:

--- a/partitura/io/importnakamura.py
+++ b/partitura/io/importnakamura.py
@@ -148,9 +148,7 @@ def load_nakamuramatch(filename: PathLike) -> Tuple[Union[np.ndarray, list]]:
     # load missing notes
     missing = np.fromregex(filename, pattern, dtype=dtype_missing)
 
-    midi_pitch = np.array(
-        [note_name_to_midi_pitch(n) for n in result["alignSitch"]]
-    )
+    midi_pitch = np.array([note_name_to_midi_pitch(n) for n in result["alignSitch"]])
 
     align_valid = result["alignID"] != "*"
     n_align = sum(align_valid)

--- a/partitura/io/musescore.py
+++ b/partitura/io/musescore.py
@@ -91,7 +91,8 @@ def find_musescore():
                 )
             else:
                 raise MuseScoreNotFoundException()
-    if "DISPLAY" not in os.environ:
+    # check if a screen is available (only on Linux)
+    if "DISPLAY" not in os.environ and platform.system() == "Linux":
         raise MuseScoreNotFoundException(
             "Musescore Executable was found, but a screen is missing. Musescore needs a screen to load scores"
         )


### PR DESCRIPTION
The current `matchfile_from_alignment` from alignment uses the document order of notes in line 361 (exportmatch,py)
```
snote_sort_info[snote.id] = (onset_beats, snote.doc_order)
```
to later on sort by this value in line 460 ff
```
sort_stime = np.array(sort_stime)
sort_stime_idx = np.lexsort((sort_stime[:, 1], sort_stime[:, 0]))
note_lines = np.array(note_lines)[sort_stime_idx]
```

`doc_order` is a standard note property but it's only used for musicxml files so far. Scores/parts imported from match/mei/kern/midi do not have this property and the sorting breaks. A doc_order property shouldn't be a hard requirement though, so the doc_order extraction is now:
``` 
snote_sort_info[snote.id] = (onset_beats, snote.doc_order if snote.doc_order is not None else 0)
```