### PR TITLE
fix pattern checking

### DIFF
--- a/partitura/io/matchfile_base.py
+++ b/partitura/io/matchfile_base.py
@@ -799,7 +799,20 @@ class BaseDeletionLine(MatchLine):
         matchline: str,
         snote_class: BaseSnoteLine,
         version: Version,
-    ) -> Dict:
+        pos: int = 0,
+    ) -> Dict:       
+        # this is very roundabout, but since this is a class method
+        # we can't use instance properties without a dummy instance of cls.
+        # and the note class pattern is only set when instantiated
+        # for some note classes (expecially v0)
+        dummy_snote = snote_class(version = version,anchor= 0,note_name="C",
+                            modifier="",octave=4,measure=0,beat=0, 
+                            offset=FractionalSymbolicDuration(1),duration=FractionalSymbolicDuration(1),
+                            onset_in_beats=0.0,offset_in_beats=0.0,score_attributes_list=[])
+        dummy_instance = cls(version = version, snote= dummy_snote)
+        match_pattern = dummy_instance.pattern.search(matchline, pos=pos)
+        if match_pattern is None:
+            raise MatchError("")
         snote = snote_class.from_matchline(matchline, version=version)
 
         kwargs = dict(
@@ -841,7 +854,24 @@ class BaseInsertionLine(MatchLine):
         matchline: str,
         note_class: BaseNoteLine,
         version: Version,
+        pos: int = 0,
     ) -> Dict:
+        # this is very roundabout, but since this is a class method
+        # we can't use instance properties without a dummy instance of cls.
+        # and the note class pattern is only set when instantiated
+        # for some note classes (expecially v0)
+        if version >= Version(1, 0, 0):
+            dummy_note = note_class(version = version, id="id",midi_pitch=60,
+                                    onset=0,offset=0,velocity=0,channel=0,track=0)
+        else:
+            dummy_note = note_class(version = version, id="id", note_name="C", 
+                                    modifier=0, octave= 0, onset= 0, offset= 0, velocity= 0)
+        
+        dummy_instance = cls(version = version, note= dummy_note)
+        match_pattern = dummy_instance.pattern.search(matchline, pos=pos)
+        if match_pattern is None:
+            raise MatchError("")
+
         note = note_class.from_matchline(matchline, version=version)
 
         kwargs = dict(


### PR DESCRIPTION
There was no checking for any specific patterns in deletions and insertions, just matching with respect the base pattern of notes and snotes. This meant that the classes:
- `MatchSnoteTrailingScore`
- `MatchSnoteNoPlayedNote`
were never used and always ended up as `MatchSnoteDeletion` and the classes:
- `MatchHammerBounceNote`
- `MatchTrailingPlayedNote`
- `MatchTrillNote`
were never used and always ended up as `MatchInsertionNote`. (which was mentioned in issue #286 )

The fix creates dummy instances in the base class methods to check for the correct patterns. This is a bit weird, but some of the classes only fix the patterns at instantiation, so I didn't know how else to get to the pattern. All above note classes are now correctly parsed and the parser further discards spurious lines such as `spurious_tag-note(606,[G,#],5,63037,63119,63119,67).` for not recognizing the pattern (this would previously have been an insertion).
