### PR TITLE
solution without dummies

### DIFF
--- a/partitura/io/importmatch.py
+++ b/partitura/io/importmatch.py
@@ -210,7 +210,9 @@ def load_matchfile(
         parse_matchline, version=version, from_matchline_methods=from_matchline_methods
     )
     f_vec = np.vectorize(f)
-    parsed_lines = f_vec(np_lines).tolist()
+    parsed_lines_raw = f_vec(np_lines).tolist()
+    # do not return unparseable lines
+    parsed_lines = [line for line in parsed_lines_raw if line is not None]
     # Create MatchFile instance
     mf = MatchFile(lines=parsed_lines)
     # Validate match for duplicate snote_ids or pnote_ids

--- a/partitura/io/matchfile_base.py
+++ b/partitura/io/matchfile_base.py
@@ -770,6 +770,7 @@ class BaseSnoteNoteLine(MatchLine):
 
 class BaseDeletionLine(MatchLine):
     out_pattern = "{SnoteLine}-deletion."
+    identifier_pattern = re.compile(r"-deletion\.")
 
     def __init__(self, version: Version, snote: BaseSnoteLine) -> None:
         super().__init__(version)
@@ -801,26 +802,9 @@ class BaseDeletionLine(MatchLine):
         version: Version,
         pos: int = 0,
     ) -> Dict:
-        # this is very roundabout, but since this is a class method
-        # we can't use instance properties without a dummy instance of cls.
-        # and the note class pattern is only set when instantiated
-        # for some note classes (expecially v0)
-        dummy_snote = snote_class(
-            version=version,
-            anchor=0,
-            note_name="C",
-            modifier="",
-            octave=4,
-            measure=0,
-            beat=0,
-            offset=FractionalSymbolicDuration(1),
-            duration=FractionalSymbolicDuration(1),
-            onset_in_beats=0.0,
-            offset_in_beats=0.0,
-            score_attributes_list=[],
-        )
-        dummy_instance = cls(version=version, snote=dummy_snote)
-        match_pattern = dummy_instance.pattern.search(matchline, pos=pos)
+
+        match_pattern = cls.identifier_pattern.search(matchline, pos=pos)
+
         if match_pattern is None:
             raise MatchError("")
         snote = snote_class.from_matchline(matchline, version=version)
@@ -835,6 +819,7 @@ class BaseDeletionLine(MatchLine):
 
 class BaseInsertionLine(MatchLine):
     out_pattern = "insertion-{NoteLine}"
+    identifier_pattern = re.compile(r"insertion-")
 
     def __init__(self, version: Version, note: BaseNoteLine) -> None:
         super().__init__(version)
@@ -866,35 +851,9 @@ class BaseInsertionLine(MatchLine):
         version: Version,
         pos: int = 0,
     ) -> Dict:
-        # this is very roundabout, but since this is a class method
-        # we can't use instance properties without a dummy instance of cls.
-        # and the note class pattern is only set when instantiated
-        # for some note classes (expecially v0)
-        if version >= Version(1, 0, 0):
-            dummy_note = note_class(
-                version=version,
-                id="id",
-                midi_pitch=60,
-                onset=0,
-                offset=0,
-                velocity=0,
-                channel=0,
-                track=0,
-            )
-        else:
-            dummy_note = note_class(
-                version=version,
-                id="id",
-                note_name="C",
-                modifier=0,
-                octave=0,
-                onset=0,
-                offset=0,
-                velocity=0,
-            )
 
-        dummy_instance = cls(version=version, note=dummy_note)
-        match_pattern = dummy_instance.pattern.search(matchline, pos=pos)
+        match_pattern = cls.identifier_pattern.search(matchline, pos=pos)
+
         if match_pattern is None:
             raise MatchError("")
 

--- a/partitura/io/matchlines_v0.py
+++ b/partitura/io/matchlines_v0.py
@@ -805,6 +805,7 @@ class MatchSnoteDeletion(BaseDeletionLine):
 
 class MatchSnoteTrailingScore(MatchSnoteDeletion):
     out_pattern = "{SnoteLine}-trailing_score_note."
+    identifier_pattern = re.compile(r"-trailing_score_note\.")
 
     def __init__(self, version: Version, snote: MatchSnote) -> None:
         super().__init__(version=version, snote=snote)
@@ -815,6 +816,7 @@ class MatchSnoteTrailingScore(MatchSnoteDeletion):
 
 class MatchSnoteNoPlayedNote(MatchSnoteDeletion):
     out_pattern = "{SnoteLine}-no_played_note."
+    identifier_pattern = re.compile(r"-no_played_note\.")
 
     def __init__(self, version: Version, snote: MatchSnote) -> None:
         super().__init__(version=version, snote=snote)
@@ -848,6 +850,7 @@ class MatchInsertionNote(BaseInsertionLine):
 
 class MatchHammerBounceNote(MatchInsertionNote):
     out_pattern = "hammer_bounce-{NoteLine}"
+    identifier_pattern = re.compile(r"hammer_bounce-")
 
     def __init__(self, version: Version, note: MatchNote) -> None:
         super().__init__(version=version, note=note)
@@ -856,6 +859,7 @@ class MatchHammerBounceNote(MatchInsertionNote):
 
 class MatchTrailingPlayedNote(MatchInsertionNote):
     out_pattern = "trailing_played_note-{NoteLine}"
+    identifier_pattern = re.compile(r"trailing_played_note-")
 
     def __init__(self, version: Version, note: MatchNote) -> None:
         super().__init__(version=version, note=note)


### PR DESCRIPTION
I found a solution for correct match line parsing that doesn't involve dummies, but additional identifying patterns that are independent of the match(s)note class and its version.