### PR TITLE
Track all MIDI messages for PerformedPart objects

### DIFF
--- a/partitura/io/importmidi.py
+++ b/partitura/io/importmidi.py
@@ -6,7 +6,7 @@ This module contains methods for importing MIDI files.
 import warnings
 
 from collections import defaultdict
-from typing import Union, Optional, List, Tuple
+from typing import Union, Optional, List, Tuple, Dict
 import numpy as np
 
 
@@ -655,7 +655,11 @@ def make_track_to_part_mapping(tr_ch_keys, group_part_voice_keys):
     return track_to_part_keys
 
 
-def assign_group_part_voice(mode, track_ch_combis, track_names):
+def assign_group_part_voice(
+    mode: int,
+    track_ch_combis: Dict[Tuple[int, int], List],
+    track_names: Dict[int, str],
+) -> Tuple[List[Tuple], Dict, Dict]:
     """
     0: return one Part per track, with voices assigned by channel
     1. return one PartGroup per track, with Parts assigned by channel (no voices)
@@ -730,6 +734,29 @@ def create_part(
     part_id: Optional[str] = None,
     part_name: Optional[str] = None,
 ) -> score.Part:
+    """
+    Create score part object
+
+    Parameters
+    ----------
+    ticks: int
+        Integer unit to represent onset and duration information
+        in the score in a lossless way.
+    notes: List[Tuple[int, int, int]]
+        Note information (onset, pitch, duration)
+    spellings: List[Tuple[str, str, int]]
+    voices: List[str]
+    note_ids: List[str]
+    time_sigs: List[Tuple[int, int, int]]
+    key_sigs:
+    part_id
+    part_name
+
+    Returns
+    -------
+    part: partitura.score.Part
+        An object representing a Part in the score
+    """
     warnings.warn("create_part", stacklevel=2)
 
     part = score.Part(part_id, part_name=part_name)

--- a/partitura/io/importmidi.py
+++ b/partitura/io/importmidi.py
@@ -6,7 +6,7 @@ This module contains methods for importing MIDI files.
 import warnings
 
 from collections import defaultdict
-from typing import Union, Optional
+from typing import Union, Optional, List, Tuple
 import numpy as np
 
 
@@ -409,7 +409,13 @@ or a list of these
     track_names_by_track = {}
     # notes are indexed by (track, channel) tuples
     notes_by_track_ch = {}
-    relevant = {"time_signature", "key_signature", "set_tempo", "note_on", "note_off"}
+    relevant = {
+        "time_signature",
+        "key_signature",
+        "set_tempo",
+        "note_on",
+        "note_off",
+    }
     for track_nr, track in enumerate(mid.tracks):
         time_sigs = []
         key_sigs = []
@@ -714,15 +720,15 @@ def assign_group_part_voice(mode, track_ch_combis, track_names):
 
 
 def create_part(
-    ticks,
-    notes,
-    spellings,
-    voices,
-    note_ids,
-    time_sigs,
-    key_sigs,
-    part_id=None,
-    part_name=None,
+    ticks: int,
+    notes: List[Tuple[int, int, int]],
+    spellings: List[Tuple[str, str, int]],
+    voices: List[int],
+    note_ids: List[str],
+    time_sigs: List[Tuple[int, int, int]],
+    key_sigs: List[Tuple[int, str]],
+    part_id: Optional[str] = None,
+    part_name: Optional[str] = None,
 ) -> score.Part:
     warnings.warn("create_part", stacklevel=2)
 
@@ -814,7 +820,10 @@ def create_part(
     return part
 
 
-def quantize(v, unit):
+def quantize(
+    v: Union[np.ndarray, float, int],
+    unit: Union[float, int],
+) -> Union[np.ndarray, float, int]:
     """Quantize value `v` to a multiple of `unit`. When `unit` is an integer,
     the return value will be integer as well, otherwise the function will
     return a float.

--- a/partitura/performance.py
+++ b/partitura/performance.py
@@ -77,6 +77,9 @@ class PerformedPart(object):
         part_name: str = None,
         controls: List[dict] = None,
         programs: List[dict] = None,
+        key_signatures: List[dict] = None,
+        time_signatures: List[dict] = None,
+        meta_other: List[dict] = None,
         sustain_pedal_threshold: int = 64,
         ppq: int = 480,
         mpq: int = 500000,
@@ -92,6 +95,9 @@ class PerformedPart(object):
         )
         self.controls = controls or []
         self.programs = programs or []
+        self.time_signatures = time_signatures or []
+        self.key_signature = key_signatures or []
+        self.meta_other = meta_other or []
         self.ppq = ppq
         self.mpq = mpq
         self.track = track

--- a/partitura/performance.py
+++ b/partitura/performance.py
@@ -96,7 +96,7 @@ class PerformedPart(object):
         self.controls = controls or []
         self.programs = programs or []
         self.time_signatures = time_signatures or []
-        self.key_signature = key_signatures or []
+        self.key_signatures = key_signatures or []
         self.meta_other = meta_other or []
         self.ppq = ppq
         self.mpq = mpq


### PR DESCRIPTION
This pull request allows PerformedPart objects to track all MIDI message types. In particular it allows for tracking the following information

* key signature
* time signature
* Meta MIDI messages

While this information is not necessarily reliable in performed MIDI files, it might be sometimes useful, in particular for generated music/performances.