### PR TITLE
Export wav using fluidsynth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ static
 
 # phdocs
 phdocs.txt
+
+# fluidsynth default soundfont
+partitura/assets/MuseScore_General.sf2

--- a/.gitignore
+++ b/.gitignore
@@ -154,4 +154,4 @@ static
 phdocs.txt
 
 # fluidsynth default soundfont
-partitura/assets/MuseScore_General.sf2
+partitura/assets/MuseScore_General.sf*

--- a/partitura/__init__.py
+++ b/partitura/__init__.py
@@ -22,7 +22,7 @@ from .io.exportmatch import save_match
 from .io.importnakamura import load_nakamuramatch, load_nakamuracorresp
 from .io.importparangonada import load_parangonada_csv
 from .io.exportparangonada import save_parangonada_csv, save_csv_for_parangonada
-from .io.exportaudio import save_wav
+from .io.exportaudio import save_wav, save_wav_fluidsynth
 from .io.exportmei import save_mei
 from .display import render
 from . import musicanalysis
@@ -61,5 +61,7 @@ __all__ = [
     "load_nakamuracorresp",
     "load_parangonada_csv",
     "save_parangonada_csv",
+    "save_wav",
+    "save_wav_fluidsynth",
     "render",
 ]

--- a/partitura/io/exportaudio.py
+++ b/partitura/io/exportaudio.py
@@ -133,7 +133,7 @@ def save_wav_fluidsynth(
     samplerate: int
         The sample rate of the audio file in Hz. The default is 44100Hz.
     soundfont : PathLike
-        Path to the soundfont in SF2 format for fluidsynth.
+        Path to the soundfont in SF2/SF3 format for fluidsynth.
     bpm : float, np.ndarray, callable
         The bpm to render the output (if the input is a score-like object).
         See `partitura.utils.music.performance_notearray_from_score_notearray`

--- a/partitura/io/exportaudio.py
+++ b/partitura/io/exportaudio.py
@@ -144,6 +144,10 @@ def save_wav_fluidsynth(
     audio_signal : np.ndarray
        Audio signal as a 1D array. Only returned if `out` is None.
     """
+
+    if not HAS_FLUIDSYNTH:
+        raise ImportError("Fluidsynth is not installed!")
+
     audio_signal = synthesize_fluidsynth(
         note_info=input_data,
         samplerate=samplerate,

--- a/partitura/io/exportaudio.py
+++ b/partitura/io/exportaudio.py
@@ -1,8 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-This module contains methods to synthesize Partitura object to wav using
-additive synthesis
+This module contains methods to synthesize Partitura object to wav.
 """
 from typing import Union, Optional, Callable, Dict, Any
 import numpy as np
@@ -13,10 +12,18 @@ from partitura.score import ScoreLike
 from partitura.performance import PerformanceLike
 
 from partitura.utils.synth import synthesize, SAMPLE_RATE, A4
+from partitura.utils.fluidsynth import (
+    synthesize_fluidsynth,
+    DEFAULT_SOUNDFONT,
+    HAS_FLUIDSYNTH,
+)
 
 from partitura.utils.misc import PathLike
 
-__all__ = ["save_wav"]
+__all__ = [
+    "save_wav",
+    "save_wav_fluidsynth",
+]
 
 
 def save_wav(
@@ -92,5 +99,59 @@ def save_wav(
     if out is not None:
         # Write audio signal
         wavfile.write(out, samplerate, audio_signal)
+    else:
+        return audio_signal
+
+
+def save_wav_fluidsynth(
+    input_data: Union[ScoreLike, PerformanceLike, np.ndarray],
+    out: Optional[PathLike] = None,
+    samplerate: int = SAMPLE_RATE,
+    soundfont: PathLike = DEFAULT_SOUNDFONT,
+    bpm: Union[float, np.ndarray, Callable] = 60,
+) -> Optional[np.ndarray]:
+    """
+    Export a score (a `Score`, `Part`, `PartGroup` or list of `Part` instances),
+    a performance (`Performance`, `PerformedPart` or list of `PerformedPart` instances)
+    as a WAV file using fluidsynth
+
+    Parameters
+    ----------
+    input_data : ScoreLike, PerformanceLike or np.ndarray
+        A partitura object with note information.
+    out : PathLike or None
+        Path of the output Wave file. If None, the method outputs
+        the audio signal as an array (see `audio_signal` below).
+    samplerate: int
+        The sample rate of the audio file in Hz. The default is 44100Hz.
+    soundfont : PathLike
+        Path to the soundfont in SF2 format for fluidsynth.
+    bpm : float, np.ndarray, callable
+        The bpm to render the output (if the input is a score-like object).
+        See `partitura.utils.music.performance_notearray_from_score_notearray`
+        for more information on this parameter.
+
+    Returns
+    -------
+    audio_signal : np.ndarray
+       Audio signal as a 1D array. Only returned if `out` is None.
+    """
+    audio_signal = synthesize_fluidsynth(
+        note_info=input_data,
+        samplerate=samplerate,
+        soundfont=soundfont,
+        bpm=bpm,
+    )
+
+    if out is not None:
+        # Write audio signal
+
+        # convert to 16bit integers (save as PCM 16 bit)
+        amplitude = np.iinfo(np.int16).max
+        if abs(audio_signal).max() <= 1:
+            # convert to 16bit integers (save as PCM 16 bit)
+            amplitude = np.iinfo(np.int16).max
+            audio_signal *= amplitude
+        wavfile.write(out, samplerate, audio_signal.astype(np.int16))
     else:
         return audio_signal

--- a/partitura/io/exportaudio.py
+++ b/partitura/io/exportaudio.py
@@ -97,8 +97,16 @@ def save_wav(
     )
 
     if out is not None:
-        # Write audio signal
-        wavfile.write(out, samplerate, audio_signal)
+        # convert to 16bit integers (save as PCM 16 bit)
+        # (some DAWs cannot load audio files that are float64,
+        # e.g., Logic)
+        amplitude = np.iinfo(np.int16).max
+        if abs(audio_signal).max() <= 1:
+            # convert to 16bit integers (save as PCM 16 bit)
+            amplitude = np.iinfo(np.int16).max
+            audio_signal *= amplitude
+        wavfile.write(out, samplerate, audio_signal.astype(np.int16))
+
     else:
         return audio_signal
 
@@ -147,6 +155,8 @@ def save_wav_fluidsynth(
         # Write audio signal
 
         # convert to 16bit integers (save as PCM 16 bit)
+        # (some DAWs cannot load audio files that are float64,
+        # e.g., Logic)
         amplitude = np.iinfo(np.int16).max
         if abs(audio_signal).max() <= 1:
             # convert to 16bit integers (save as PCM 16 bit)

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -395,7 +395,7 @@ def matchfile_from_alignment(
             onset=onset,
             offset=offset,
             velocity=pnote["velocity"],
-            channel=pnote.get("channel", 1),
+            channel=pnote.get("channel", 0),
             track=pnote.get("track", 0),
         )
         pnote_sort_info[pnote["id"]] = (

--- a/partitura/io/importmatch.py
+++ b/partitura/io/importmatch.py
@@ -394,7 +394,7 @@ def performed_part_from_match(
                 sound_off=midi_ticks_to_seconds(note.Offset, mpq, ppq),
                 velocity=note.Velocity,
                 track=getattr(note, "Track", 0),
-                channel=getattr(note, "Channel", 1),
+                channel=getattr(note, "Channel", 0),
             )
         )
     # Set first note_on to zero in ticks and seconds if first_note_at_zero

--- a/partitura/musicanalysis/performance_codec.py
+++ b/partitura/musicanalysis/performance_codec.py
@@ -819,12 +819,13 @@ def get_matched_notes(spart_note_array, ppart_note_array, alignment):
             else:
                 p_id = al["performance_id"]
 
-            p_idx = int(np.where(ppart_note_array["id"] == p_id)[0])
+            p_idx = np.where(ppart_note_array["id"] == p_id)[0]
 
             s_idx = np.where(spart_note_array["id"] == al["score_id"])[0]
 
-            if len(s_idx) > 0:
+            if len(s_idx) > 0 and len(p_idx) > 0:
                 s_idx = int(s_idx)
+                p_idx = int(p_idx)
                 matched_idxs.append((s_idx, p_idx))
 
     return np.array(matched_idxs)

--- a/partitura/utils/fluidsynth.py
+++ b/partitura/utils/fluidsynth.py
@@ -1,0 +1,265 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+This module contains methods for synthesizing score- or performance-like
+objects using fluidsynth. Fluidsynth is an optional dependency.
+
+"""
+
+import os
+from collections import defaultdict
+from typing import Callable, Optional, Union
+
+import numpy as np
+import partitura as pt
+
+try:
+    from fluidsynth import Synth
+
+    HAS_FLUIDSYNTH = True
+except ImportError:
+    Synth = None
+    HAS_FLUIDSYNTH = False
+
+from partitura.io.exportaudio import SAMPLE_RATE
+from partitura.performance import PerformanceLike
+from partitura.score import ScoreLike
+from partitura.utils.misc import PathLike, download_file
+from partitura.utils.music import (
+    ensure_notearray,
+    get_time_units_from_note_array,
+    performance_notearray_from_score_notearray,
+)
+from scipy.io import wavfile
+
+# MuseScore's soundfont distributed under the License.
+DEFAULT_SOUNDFONT_URL = "ftp://ftp.osuosl.org/pub/musescore/soundfont/MuseScore_General/MuseScore_General.sf2"
+
+DEFAULT_SOUNDFONT = os.path.join(pt.__path__, "assets", "MuseScore_General.sf2")
+
+if not os.path.exists(DEFAULT_SOUNDFONT) and HAS_FLUIDSYNTH:
+
+    download_file(
+        url=DEFAULT_SOUNDFONT_URL,
+        out=DEFAULT_SOUNDFONT,
+    )
+
+
+def synthesize_fluidsynth(
+    note_info: Union[ScoreLike, PerformanceLike, np.ndarray],
+    samplerate: int = SAMPLE_RATE,
+    soundfont: str = DEFAULT_SOUNDFONT,
+    bpm: Union[float, np.ndarray, Callable] = 60,
+) -> np.ndarray:
+
+    if not HAS_FLUIDSYNTH:
+        raise ImportError("Fluidsynth is not installed!")
+
+    if isinstance(note_info, pt.performance.Performance):
+        for ppart in note_info:
+            ppart.sustain_pedal_threshold = 127
+
+    if isinstance(note_info, pt.performance.PerformedPart):
+        note_info.sustain_pedal_threshold = 127
+    note_array = ensure_notearray(note_info)
+
+    onset_unit, _ = get_time_units_from_note_array(note_array)
+    if np.min(note_array[onset_unit]) <= 0:
+        note_array[onset_unit] = note_array[onset_unit] + np.min(note_array[onset_unit])
+
+    pitch = note_array["pitch"]
+    # If the input is a score, convert score time to seconds
+    if onset_unit != "onset_sec":
+        pnote_array = performance_notearray_from_score_notearray(
+            snote_array=note_array,
+            bpm=bpm,
+        )
+        onsets = pnote_array["onset_sec"]
+        offsets = pnote_array["onset_sec"] + pnote_array["duration_sec"]
+        # duration = pnote_array["duration_sec"]
+        channel = pnote_array["channel"]
+        track = pnote_array["track"]
+        velocity = pnote_array["velocity"]
+    else:
+        onsets = note_array["onset_sec"]
+        offsets = note_array["onset_sec"] + note_array["duration_sec"]
+        # duration = note_array["duration_sec"]
+
+        if "velocity" in note_array.dtype.names:
+            velocity = note_array["velocity"]
+        else:
+            velocity = np.ones(len(onsets), dtype=int) * 64
+        if "channel" in note_array.dtype.names:
+            channel = note_array["channel"]
+        else:
+            channel = np.zeros(len(onsets), dtype=int)
+
+        if "track" in note_array.dtype.names:
+            track = note_array["track"]
+        else:
+            track = np.zeros(len(onsets), dtype=int)
+
+    controls = []
+    if isinstance(note_info, pt.performance.Performance):
+
+        for ppart in note_info:
+            controls += ppart.controls
+
+    unique_tracks = list(
+        set(list(np.unique(track)) + list(set([c["track"] for c in controls])))
+    )
+
+    track_dict = defaultdict(lambda: defaultdict(list))
+
+    for tn in unique_tracks:
+        track_idxs = np.where(track == tn)[0]
+
+        track_channels = channel[track_idxs]
+        track_pitch = pitch[track_idxs]
+        track_onsets = onsets[track_idxs]
+        track_offsets = offsets[track_idxs]
+        track_velocity = velocity[track_idxs]
+
+        unique_channels = np.unique(track_channels)
+
+        track_controls = [c for c in controls if c["track"] == tn]
+
+        for chn in unique_channels:
+
+            channel_idxs = np.where(track_channels == chn)[0]
+
+            channel_pitch = track_pitch[channel_idxs]
+            channel_onset = track_onsets[channel_idxs]
+            channel_offset = track_offsets[channel_idxs]
+            channel_velocity = track_velocity[channel_idxs]
+
+            channel_controls = [c for c in track_controls if c["channel"] == chn]
+
+            track_dict[tn][chn] = [
+                channel_pitch,
+                channel_onset,
+                channel_offset,
+                channel_velocity,
+                channel_controls,
+            ]
+
+    # set to mono
+    synthesizer = Synth(samplerate=SAMPLE_RATE)
+    sf_id = synthesizer.sfload(soundfont)
+
+    audio_signals = []
+    for tn, channel_info in track_dict.items():
+
+        for chn, (pi, on, off, vel, ctrls) in channel_info.items():
+
+            audio_signal = synth_note_info(
+                pitch=pi,
+                onsets=on,
+                offsets=off,
+                velocities=vel,
+                controls=ctrls,
+                program=None,
+                synthesizer=synthesizer,
+                sf_id=sf_id,
+                channel=chn,
+                samplerate=samplerate,
+            )
+            audio_signals.append(audio_signal)
+
+    # pad audio signals:
+
+    signal_lengths = [len(signal) for signal in audio_signals]
+    max_len = np.max(signal_lengths)
+
+    output_audio_signal = np.zeros(max_len)
+
+    for sl, audio_signal in zip(signal_lengths, audio_signals):
+
+        output_audio_signal[:sl] += audio_signal
+
+    # normalization term
+    norm_term = max(audio_signal.max(), abs(audio_signal.min()))
+    output_audio_signal /= norm_term
+
+    return output_audio_signal
+
+
+def synth_note_info(
+    pitch: np.ndarray,
+    onsets: np.ndarray,
+    offsets: np.ndarray,
+    velocities: np.ndarray,
+    controls: Optional[list],
+    program: Optional[int],
+    synthesizer: Synth,
+    sf_id: int,
+    channel: int,
+    samplerate: int = SAMPLE_RATE,
+) -> np.ndarray:
+
+    # set program
+    synthesizer.program_select(channel, sf_id, 0, program or 0)
+
+    # TODO: extend piece duration to account for pedal info.
+    if len(controls) > 0 and len(offsets) > 0:
+        piece_duration = max(offsets.max(), np.max([c["time"] for c in controls]))
+    elif len(controls) > 0 and len(offsets) == 0:
+        piece_duration = np.max([c["time"] for c in controls])
+    elif len(controls) == 0 and len(offsets) > 0:
+        piece_duration = offsets.max()
+    else:
+        # return a single zero
+        audio_signal = np.zeros(1)
+        return audio_signal
+
+    num_frames = int(np.round(piece_duration * samplerate))
+
+    # Initialize array containing audio
+    audio_signal = np.zeros(num_frames, dtype="float")
+
+    # Initialize the time axis
+    x = np.linspace(0, piece_duration, num=num_frames)
+
+    # onsets in frames (i.e., indices of the `audio_signal` array)
+    onsets_in_frames = np.searchsorted(x, onsets, side="left")
+    offsets_in_frames = np.searchsorted(x, offsets, side="left")
+
+    messages = []
+    for ctrl in controls or []:
+
+        messages.append(
+            (
+                "cc",
+                channel,
+                ctrl["number"],
+                ctrl["value"],
+                np.searchsorted(x, ctrl["time"], side="left"),
+            )
+        )
+
+    for pi, vel, oif, ofif in zip(
+        pitch, velocities, onsets_in_frames, offsets_in_frames
+    ):
+
+        messages += [
+            ("noteon", channel, pi, vel, oif),
+            ("noteoff", channel, pi, ofif),
+        ]
+
+    # sort messages
+    messages.sort(key=lambda x: x[-1])
+
+    delta_times = [
+        int(nm[-1] - cm[-1]) for nm, cm in zip(messages[1:], messages[:-1])
+    ] + [0]
+
+    for dt, msg in zip(delta_times, messages):
+
+        msg_type = msg[0]
+        msg_time = msg[-1]
+        getattr(synthesizer, msg_type)(*msg[1:-1])
+
+        samples = synthesizer.get_samples(dt)[::2]
+        audio_signal[msg_time : msg_time + dt] = samples
+
+    return audio_signal

--- a/partitura/utils/fluidsynth.py
+++ b/partitura/utils/fluidsynth.py
@@ -30,13 +30,14 @@ from partitura.utils.music import (
     performance_notearray_from_score_notearray,
 )
 
-# MuseScore's soundfont distributed under the License.
-DEFAULT_SOUNDFONT_URL = "ftp://ftp.osuosl.org/pub/musescore/soundfont/MuseScore_General/MuseScore_General.sf2"
+# MuseScore's soundfont distributed under the MIT License.
+# https://ftp.osuosl.org/pub/musescore/soundfont/MuseScore_General/MuseScore_General_License.md
+DEFAULT_SOUNDFONT_URL = "ftp://ftp.osuosl.org/pub/musescore/soundfont/MuseScore_General/MuseScore_General.sf3"
 
 DEFAULT_SOUNDFONT = os.path.join(
     pt.__path__[0],
     "assets",
-    "MuseScore_General.sf2",
+    "MuseScore_General.sf3",
 )
 
 if not os.path.exists(DEFAULT_SOUNDFONT) and HAS_FLUIDSYNTH:  # pragma: no cover

--- a/partitura/utils/fluidsynth.py
+++ b/partitura/utils/fluidsynth.py
@@ -67,7 +67,7 @@ def synthesize_fluidsynth(
         The sample rate of the audio file in Hz.
 
     soundfont: PathLike
-        The path to the soundfont (in SF2 format).
+        The path to the soundfont (in SF2/SF3 format).
 
     bpm : float, np.ndarray or callable
         The bpm to render the output (if the input is a score-like object).
@@ -223,6 +223,41 @@ def synth_note_info(
     channel: int,
     samplerate: int = SAMPLE_RATE,
 ) -> np.ndarray:
+    """
+    Synthesize note information with Fluidsynth.
+    This method is designed to synthesize the notes in a 
+    single track and channel.
+
+    Parameters
+    ----------
+    pitch : np.ndarray
+        An array with pitch information for each note.
+    onsets : np.ndarray
+        An array with onset time in seconds for each note.
+    offsets : np.ndarray
+        An array with offset times in seconds for each note.
+    velocities : np.ndarray
+        An array with MIDI velocities for each note.
+    controls : Optional[list]
+        A list of MIDI controls (e.g., pedals).
+        (as the `controls` attribute in `PerformedPart` objects)
+    program : Optional[int]
+        A list of MIDI programs as dictionaries 
+        (as the `program` attribute in `PerformedPart` objects).
+    synthesizer : Synth
+        An instance of a fluidsynth Synth object.
+    sf_id : int
+        The id of the synthesizer object
+    channel : int
+        Channel for the the notes.
+    samplerate : int, optional
+        Sample rate, by default SAMPLE_RATE
+
+    Returns
+    -------
+    audio_signal : np.ndarray
+        A 1D array with the synthesized audio signal.
+    """
 
     # set program
     synthesizer.program_select(channel, sf_id, 0, program or 0)

--- a/partitura/utils/fluidsynth.py
+++ b/partitura/utils/fluidsynth.py
@@ -16,11 +16,11 @@ try:
     from fluidsynth import Synth
 
     HAS_FLUIDSYNTH = True
-except ImportError:
-    Synth = None
-    HAS_FLUIDSYNTH = False
+except ImportError:  # pragma: no cover
+    Synth = None  # pragma: no cover
+    HAS_FLUIDSYNTH = False  # pragma: no cover
 
-from partitura.io.exportaudio import SAMPLE_RATE
+from partitura.utils.synth import SAMPLE_RATE
 from partitura.performance import PerformanceLike
 from partitura.score import ScoreLike
 from partitura.utils.misc import PathLike, download_file
@@ -29,19 +29,22 @@ from partitura.utils.music import (
     get_time_units_from_note_array,
     performance_notearray_from_score_notearray,
 )
-from scipy.io import wavfile
 
 # MuseScore's soundfont distributed under the License.
 DEFAULT_SOUNDFONT_URL = "ftp://ftp.osuosl.org/pub/musescore/soundfont/MuseScore_General/MuseScore_General.sf2"
 
-DEFAULT_SOUNDFONT = os.path.join(pt.__path__[0], "assets", "MuseScore_General.sf2")
+DEFAULT_SOUNDFONT = os.path.join(
+    pt.__path__[0],
+    "assets",
+    "MuseScore_General.sf2",
+)
 
-if not os.path.exists(DEFAULT_SOUNDFONT) and HAS_FLUIDSYNTH:
-    print(f"Downloading soundfont from {DEFAULT_SOUNDFONT_URL}...")
+if not os.path.exists(DEFAULT_SOUNDFONT) and HAS_FLUIDSYNTH:  # pragma: no cover
+    print(f"Downloading soundfont from {DEFAULT_SOUNDFONT_URL}...")  # pragma: no cover
     download_file(
         url=DEFAULT_SOUNDFONT_URL,
         out=DEFAULT_SOUNDFONT,
-    )
+    )  # pragma: no cover
 
 
 def synthesize_fluidsynth(
@@ -58,10 +61,13 @@ def synthesize_fluidsynth(
     ----------
     note_info : ScoreLike, PerformanceLike or np.ndarray
         A partitura object with note information.
+
     samplerate: int
         The sample rate of the audio file in Hz.
+
     soundfont: PathLike
         The path to the soundfont (in SF2 format).
+
     bpm : float, np.ndarray or callable
         The bpm to render the output (if the input is a score-like object).
         See `partitura.utils.music.performance_notearray_from_score_notearray`
@@ -74,7 +80,7 @@ def synthesize_fluidsynth(
     """
 
     if not HAS_FLUIDSYNTH:
-        raise ImportError("Fluidsynth is not installed!")
+        raise ImportError("Fluidsynth is not installed!")  # pragma: no cover
 
     if isinstance(note_info, pt.performance.Performance):
         for ppart in note_info:
@@ -220,7 +226,6 @@ def synth_note_info(
     # set program
     synthesizer.program_select(channel, sf_id, 0, program or 0)
 
-    # TODO: extend piece duration to account for pedal info.
     if len(controls) > 0 and len(offsets) > 0:
         piece_duration = max(offsets.max(), np.max([c["time"] for c in controls]))
     elif len(controls) > 0 and len(offsets) == 0:

--- a/partitura/utils/fluidsynth.py
+++ b/partitura/utils/fluidsynth.py
@@ -3,7 +3,6 @@
 """
 This module contains methods for synthesizing score- or performance-like
 objects using fluidsynth. Fluidsynth is an optional dependency.
-
 """
 
 import os
@@ -35,10 +34,10 @@ from scipy.io import wavfile
 # MuseScore's soundfont distributed under the License.
 DEFAULT_SOUNDFONT_URL = "ftp://ftp.osuosl.org/pub/musescore/soundfont/MuseScore_General/MuseScore_General.sf2"
 
-DEFAULT_SOUNDFONT = os.path.join(pt.__path__, "assets", "MuseScore_General.sf2")
+DEFAULT_SOUNDFONT = os.path.join(pt.__path__[0], "assets", "MuseScore_General.sf2")
 
 if not os.path.exists(DEFAULT_SOUNDFONT) and HAS_FLUIDSYNTH:
-
+    print(f"Downloading soundfont from {DEFAULT_SOUNDFONT_URL}...")
     download_file(
         url=DEFAULT_SOUNDFONT_URL,
         out=DEFAULT_SOUNDFONT,
@@ -48,9 +47,31 @@ if not os.path.exists(DEFAULT_SOUNDFONT) and HAS_FLUIDSYNTH:
 def synthesize_fluidsynth(
     note_info: Union[ScoreLike, PerformanceLike, np.ndarray],
     samplerate: int = SAMPLE_RATE,
-    soundfont: str = DEFAULT_SOUNDFONT,
+    soundfont: PathLike = DEFAULT_SOUNDFONT,
     bpm: Union[float, np.ndarray, Callable] = 60,
 ) -> np.ndarray:
+    """
+    Synthesize partitura object with note information using
+    fluidsynth.
+
+    Parameters
+    ----------
+    note_info : ScoreLike, PerformanceLike or np.ndarray
+        A partitura object with note information.
+    samplerate: int
+        The sample rate of the audio file in Hz.
+    soundfont: PathLike
+        The path to the soundfont (in SF2 format).
+    bpm : float, np.ndarray or callable
+        The bpm to render the output (if the input is a score-like object).
+        See `partitura.utils.music.performance_notearray_from_score_notearray`
+        for more information on this parameter.
+
+    Returns
+    -------
+    output_audio_signal : np.ndarray
+       Audio signal as a 1D array.
+    """
 
     if not HAS_FLUIDSYNTH:
         raise ImportError("Fluidsynth is not installed!")
@@ -83,7 +104,6 @@ def synthesize_fluidsynth(
     else:
         onsets = note_array["onset_sec"]
         offsets = note_array["onset_sec"] + note_array["duration_sec"]
-        # duration = note_array["duration_sec"]
 
         if "velocity" in note_array.dtype.names:
             velocity = note_array["velocity"]

--- a/partitura/utils/misc.py
+++ b/partitura/utils/misc.py
@@ -6,6 +6,8 @@ This module contains miscellaneous utilities.
 import functools
 import os
 import warnings
+from urllib.request import urlopen
+from shutil import copyfileobj
 
 from typing import Union, Callable, Dict, Any, Iterable, Optional
 
@@ -254,3 +256,27 @@ def concatenate_images(
 
     else:
         return new_image
+
+
+def download_file(
+    url: str,
+    out: str,
+) -> None:
+    """
+    Download a file from a specified URL and save it to a local file path.
+
+    Parameters
+    ----------
+    url : str
+        The URL of the file to download.
+    out : str
+        The local file path where the downloaded file should be saved.
+
+    Notes
+    -----
+    This method was adapted from a Stack Overflow answer
+    (https://stackoverflow.com/a/15035466), and is distributed under the
+    CC BY-SA 4.0 license (https://creativecommons.org/licenses/by-sa/4.0/).
+    """
+    with urlopen(url) as in_stream, open(out, "wb") as out_file:
+        copyfileobj(in_stream, out_file)

--- a/partitura/utils/synth.py
+++ b/partitura/utils/synth.py
@@ -8,7 +8,8 @@ TODO
 ----
 * Add other tuning systems?
 """
-from typing import Union, Tuple, Dict, Optional, Any, Callable
+from __future__ import annotations
+from typing import Union, Tuple, Dict, Optional, Any, Callable, TYPE_CHECKING
 
 import numpy as np
 
@@ -22,6 +23,15 @@ from partitura.utils.music import (
     midi_pitch_to_frequency,
     performance_notearray_from_score_notearray,
 )
+
+if TYPE_CHECKING:
+    # Import typing info for typing annotations.
+    # For this to work we need to import annotations from __future__
+    # Solution from
+    # https://medium.com/quick-code/python-type-hinting-eliminating-importerror-due-to-circular-imports-265dfb0580f8
+    from partitura.score import ScoreLike, Interval
+    from partitura.performance import PerformanceLike, Performance, PerformedPart
+
 
 TWO_PI = 2 * np.pi
 SAMPLE_RATE = 44100
@@ -59,6 +69,8 @@ FIVE_LIMIT_INTERVAL_RATIOS = {
     11: 15 / 8,
     12: 2,
 }
+
+
 
 
 def midi_pitch_to_natural_frequency(
@@ -374,7 +386,7 @@ class ShepardTones(object):
 
 
 def synthesize(
-    note_info,
+    note_info: Union[ScoreLike, PerformanceLike, np.ndarray],
     samplerate: int = SAMPLE_RATE,
     envelope_fun: str = "linear",
     tuning: Union[str, Callable] = "equal_temperament",

--- a/tests/test_fluidsynth.py
+++ b/tests/test_fluidsynth.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains tests for the fluidsynth methods.
+"""
+import unittest
+
+import numpy as np
+from scipy.io import wavfile
+import tempfile
+
+from partitura.utils.fluidsynth import (
+    synthesize_fluidsynth,
+    HAS_FLUIDSYNTH,
+    SAMPLE_RATE,
+)
+
+from partitura import EXAMPLE_MUSICXML, load_score, load_performance_midi
+
+from partitura.io.exportaudio import save_wav_fluidsynth
+
+from tests import MOZART_VARIATION_FILES
+
+RNG = np.random.RandomState(1984)
+
+if HAS_FLUIDSYNTH:
+
+    class TestSynthesize(unittest.TestCase):
+
+        score = load_score(EXAMPLE_MUSICXML)
+
+        def test_synthesize(self):
+
+            score_na = self.score.note_array()
+
+            duration_beats = (
+                score_na["onset_beat"] + score_na["duration_beat"]
+            ).max() - score_na["onset_beat"].min()
+
+            for bpm in RNG.randint(30, 200, size=10):
+
+                for samplerate in [12000, 16000, 22000, SAMPLE_RATE]:
+
+                    duration_sec = duration_beats * 60 / bpm
+                    y = synthesize_fluidsynth(
+                        note_info=self.score,
+                        samplerate=samplerate,
+                        bpm=bpm,
+                    )
+
+                    expected_length = np.round(duration_sec * samplerate)
+
+                    self.assertTrue(len(y) == expected_length)
+
+                    self.assertTrue(isinstance(y, np.ndarray))
+
+    class TestSynthExport(unittest.TestCase):
+
+        test_files = [
+            load_score(MOZART_VARIATION_FILES["musicxml"]),
+            load_performance_midi(MOZART_VARIATION_FILES["midi"]),
+        ]
+
+        def export(self, note_info):
+
+            y = synthesize_fluidsynth(
+                note_info=note_info,
+                samplerate=SAMPLE_RATE,
+                bpm=60,
+            )
+
+            with tempfile.TemporaryFile(suffix=".wav") as filename:
+
+                save_wav_fluidsynth(
+                    input_data=note_info,
+                    out=filename,
+                    samplerate=SAMPLE_RATE,
+                    bpm=60,
+                )
+
+                sr_rec, rec_audio = wavfile.read(filename)
+
+                self.assertTrue(sr_rec == SAMPLE_RATE)
+                self.assertTrue(len(rec_audio) == len(y))
+                self.assertTrue(
+                    np.allclose(
+                        rec_audio / rec_audio.max(),
+                        y / y.max(),
+                        atol=1e-4,
+                    )
+                )
+
+        def test_export(self):
+
+            for note_info in self.test_files:
+
+                self.export(note_info)

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-This module contains tests for the synthesis methods.
+This module contains tests for the additive synthesis methods.
 """
 import unittest
 


### PR DESCRIPTION
This pull request adds the following functionality:

* Export a partitura object to an audio file using Fluidsynth. 
    * This functionality is available in [`pretty_midi`](https://github.com/craffel/pretty-midi/blob/main/pretty_midi/fluidsynth.py), where it only works for MIDI files. 
    * Such a method is useful for cross-modal tasks (e.g., transcription, audio-to-score alignment, etc.).
    * This implementation allows for the method to work on all partitura note-based objects (`Score`, `Performance`, `Part`, `PerformedPart`, note arrays), and thus for all formats supported by partitura. 
    * Fluidsynth is treated as an optional import. Instead of adding to the repository a default soundfont (as is the case in `pretty_midi`, which includes a very small one), the default soundfont is set to be downloaded from the [MuseScore soundfonts](https://musescore.org/en/handbook/3/soundfonts-and-sfz-files#list) (which are distributed with the MIT license).

* Fixes a few minor issues in `slice_ppart_by_time` adding previously missing MIDI messages and fixing the computation of onset and offset times in ticks.