### PR TITLE
fix issue 358

### DIFF
--- a/partitura/musicanalysis/performance_codec.py
+++ b/partitura/musicanalysis/performance_codec.py
@@ -747,21 +747,15 @@ def get_time_maps_from_alignment(
 
     # Remove grace notes
     if remove_ornaments:
-        # TODO: check that all onsets have a duration?
+        # check that all onsets have a duration
         # ornaments (grace notes) do not have a duration
-        score_unique_onset_idxs = np.array(
-            [
+        score_unique_onset_idxs = [
                 np.where(np.logical_and(score_onsets == u, score_durations > 0))[0]
                 for u in score_unique_onsets
-            ],
-            dtype=object,
-        )
+            ]
 
     else:
-        score_unique_onset_idxs = np.array(
-            [np.where(score_onsets == u)[0] for u in score_unique_onsets],
-            dtype=object,
-        )
+        score_unique_onset_idxs = [np.where(score_onsets == u)[0] for u in score_unique_onsets] 
 
     # For chords, we use the average performed onset as a proxy for
     # representing the "performeance time" of the position of the score


### PR DESCRIPTION
fixes a bug in `get_time_maps_from_alignment` where arrays of idx is cast to numpy dtype objects if all score and performance idx are unique. The problem is fixed by not using numpy.