### PR TITLE
add check for empty note array

### DIFF
--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -1182,6 +1182,9 @@ def _make_pianoroll(
     onset = note_info[:, 1]
     duration = note_info[:, 2]
 
+    if len(note_info) == 0:
+        raise ValueError("Note array is empty")
+
     if np.any(duration < 0):
         raise ValueError("Note durations should be >= 0!")
 


### PR DESCRIPTION
Added a ValueError in `compute_pianorolls` when passing empty note arrays. 