### PR TITLE
Relax assertion tuplet

### DIFF
--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -1453,7 +1453,7 @@ def handle_tuplets(notations, ongoing, note):
     # assert that starting tuplet times are before stopping tuplet times
     for start_tuplet, stop_tuplet in zip(starting_tuplets, stopping_tuplets):
         assert (
-            start_tuplet.start_note.start.t < stop_tuplet.end_note.start.t
+            start_tuplet.start_note.start.t <= stop_tuplet.end_note.start.t
         ), "Tuplet start time is after tuplet stop time"
     return starting_tuplets, stopping_tuplets
 

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -3102,7 +3102,7 @@ class ChordSymbol(Harmony):
     """A harmony element in the score usually for Chord Symbols."""
 
     def __init__(self, root, kind, bass=None):
-        super().__init__(text=root + kind + (f"/{bass}" if bass else ""))
+        super().__init__(text=root + (f"/{kind}" if kind else "") + (f"/{bass}" if bass else ""))
         self.kind = kind
         self.root = root
         self.bass = bass


### PR DESCRIPTION
- Relaxing assertion for Tuplets to `start_tuplet.start_note.start.t <= stop_tuplet.end_note.start.t` to avoid error with slightly problematic scores
- Relax conditions for ChordSymbols by accepting empty kind. Sometimes, some instructions in the asap-dataset are pushed like harmony labels so, in the future, a test should ideally filter them out in partitura.