### PR TITLE
Stem Direction Support

### DIFF
--- a/partitura/io/exportmei.py
+++ b/partitura/io/exportmei.py
@@ -277,7 +277,7 @@ class MEIExporter:
         elif note.tie_prev is not None:
             note_el.set("tie", "t")
 
-        if note.stem_direction is not None:
+        if note.stem_direction in ["up", "down"]:
             note_el.set("stem.dir", note.stem_direction)
 
         if note.alter is not None:

--- a/partitura/io/exportmei.py
+++ b/partitura/io/exportmei.py
@@ -277,6 +277,9 @@ class MEIExporter:
         elif note.tie_prev is not None:
             note_el.set("tie", "t")
 
+        if note.stem_direction is not None:
+            note_el.set("stem.dir", note.stem_direction)
+
         if note.alter is not None:
             if (
                 note.step.lower() + ALTER_TO_MEI[note.alter]

--- a/partitura/io/exportmusicxml.py
+++ b/partitura/io/exportmusicxml.py
@@ -137,6 +137,10 @@ def make_note_el(note, dur, voice, counter, n_of_staves):
     if voice not in (None, 0):
         etree.SubElement(note_e, "voice").text = "{}".format(voice)
 
+    if note.stem_direction is not None:
+        stem_e = etree.SubElement(note_e, "stem")
+        stem_e.text = note.stem_direction
+
     if note.fermata is not None:
         notations.append(etree.Element("fermata"))
 

--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -1198,6 +1198,9 @@ def _handle_note(e, position, part, ongoing, prev_note, doc_order, prev_beam=Non
     # initialize beam to None
     beam = None
 
+    # get the stem direction of the note if any
+    stem_dir = get_value_from_tag(e, "stem", str) or None
+
     # add support of uppercase "ID" tags
     note_id = (
         get_value_from_attribute(e, "id", str)
@@ -1270,6 +1273,7 @@ def _handle_note(e, position, part, ongoing, prev_note, doc_order, prev_beam=Non
                 ornaments=ornaments,
                 steal_proportion=steal_proportion,
                 doc_order=doc_order,
+                stem_direction=stem_dir,
             )
             if isinstance(prev_note, score.GraceNote) and prev_note.voice == voice:
                 note.grace_prev = prev_note
@@ -1306,6 +1310,7 @@ def _handle_note(e, position, part, ongoing, prev_note, doc_order, prev_beam=Non
                 articulations=articulations,
                 ornaments=ornaments,
                 doc_order=doc_order,
+                stem_direction=stem_dir,
             )
 
         if isinstance(prev_note, score.GraceNote) and prev_note.voice == voice:
@@ -1335,6 +1340,7 @@ def _handle_note(e, position, part, ongoing, prev_note, doc_order, prev_beam=Non
             articulations=articulations,
             symbolic_duration=symbolic_duration,
             doc_order=doc_order,
+            stem_direction=stem_dir,
         )
 
     else:

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -1626,6 +1626,9 @@ class GenericNote(TimedObject):
         appearance of this note (with respect to other notes) in the
         document in case the Note belongs to a part that was imported
         from MusicXML. Defaults to None.
+    stem_direction : str, optional
+        The stem direction of the note. Can be 'up', 'down', or None.
+        Defaults to None.
 
     """
 
@@ -1638,10 +1641,13 @@ class GenericNote(TimedObject):
         articulations=None,
         ornaments=None,
         doc_order=None,
+        stem_direction=None,
         **kwargs,
     ):
         self._sym_dur = None
+
         super().__init__(**kwargs)
+
         self.voice = voice
         self.id = id
         self.staff = staff
@@ -1649,7 +1655,7 @@ class GenericNote(TimedObject):
         self.articulations = articulations
         self.ornaments = ornaments
         self.doc_order = doc_order
-
+        self.stem_direction = stem_direction if stem_direction in ("up", "down") else None
         # these attributes are set after the instance is constructed
         self.fermata = None
         self.tie_prev = None

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -1645,9 +1645,7 @@ class GenericNote(TimedObject):
         **kwargs,
     ):
         self._sym_dur = None
-
         super().__init__(**kwargs)
-
         self.voice = voice
         self.id = id
         self.staff = staff

--- a/tests/data/musicxml/test_note_ties.xml
+++ b/tests/data/musicxml/test_note_ties.xml
@@ -27,9 +27,9 @@
         <duration>15</duration>
         <tie type="start"/>
         <voice>1</voice>
+        <stem>up</stem>
         <type>quarter</type>
         <dot/>
-        <stem>up</stem>
         <notations>
           <tied type="start"/>
         </notations>

--- a/tests/data/musicxml/test_note_ties.xml
+++ b/tests/data/musicxml/test_note_ties.xml
@@ -29,6 +29,7 @@
         <voice>1</voice>
         <type>quarter</type>
         <dot/>
+        <stem>up</stem>
         <notations>
           <tied type="start"/>
         </notations>

--- a/tests/data/musicxml/test_unfold_complex_result.xml
+++ b/tests/data/musicxml/test_unfold_complex_result.xml
@@ -57,6 +57,7 @@
         </pitch>
         <duration>1</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>quarter</type>
       </note>
       <note>
@@ -66,6 +67,7 @@
         </pitch>
         <duration>1</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>quarter</type>
       </note>
     </measure>
@@ -78,6 +80,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -102,6 +105,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -114,6 +118,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -144,6 +149,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -164,6 +170,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -224,6 +231,7 @@
         </pitch>
         <duration>1</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>quarter</type>
       </note>
       <note>
@@ -233,6 +241,7 @@
         </pitch>
         <duration>1</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>quarter</type>
       </note>
     </measure>
@@ -245,6 +254,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>

--- a/tests/data/musicxml/test_unfold_dacapo_result.xml
+++ b/tests/data/musicxml/test_unfold_dacapo_result.xml
@@ -81,6 +81,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -105,6 +106,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -129,6 +131,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -147,6 +150,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -159,6 +163,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -177,6 +182,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -285,6 +291,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -309,6 +316,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>

--- a/tests/data/musicxml/test_unfold_volta_numbers_result.xml
+++ b/tests/data/musicxml/test_unfold_volta_numbers_result.xml
@@ -57,6 +57,7 @@
         </pitch>
         <duration>1</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>quarter</type>
       </note>
       <note>
@@ -66,6 +67,7 @@
         </pitch>
         <duration>1</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>quarter</type>
       </note>
     </measure>
@@ -78,6 +80,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -102,6 +105,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -114,6 +118,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -144,6 +149,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -164,6 +170,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -200,6 +207,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -224,6 +232,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -236,6 +245,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>
@@ -260,6 +270,7 @@
         </pitch>
         <duration>2</duration>
         <voice>1</voice>
+        <stem>up</stem>
         <type>half</type>
       </note>
     </measure>

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -212,6 +212,11 @@ class TestMusicXML(unittest.TestCase):
         part1 = make_part_slur()
         self._pretty_export_import_pretty_test(part1)
 
+    def test_stem_direction_import(self):
+        # test if stem direction is imported correctly for the first note of test_note_ties.xml
+        part = load_musicxml(MUSICXML_IMPORT_EXPORT_TESTFILES[0])[0]
+        self.assertEqual(part.notes_tied[0].stem_direction, "up")
+
     def _pretty_export_import_pretty_test(self, part1):
         # pretty print the part
         pstring1 = part1.pretty()


### PR DESCRIPTION
- Added support for stem direction in musicxml import/export
- Added support for stem direction export in mei export
- Added a generic note attribute called beam_direction initialized to None including minimal tests to only accept "up/down" values.
