### PR TITLE
Add a parameter to ignore invisible objects when parsing MusicXML files

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -77,6 +77,11 @@ MUSICXML_UNFOLD_DACAPO = [
     for fn1, fn2 in [("test_unfold_dacapo.xml", "test_unfold_dacapo_result.xml")]
 ]
 
+MUSICXML_IGNORE_INVISIBLE_OBJECTS = [
+    os.path.join(MUSICXML_PATH, fn)
+    for fn in ["test_ignore_invisible_objects.musicxml"]
+]
+
 # This is a list of files for testing Chew and Wu's VOSA. (More files to come?)
 VOSA_TESTFILES = [
     os.path.join(MUSICXML_PATH, fn) for fn in ["test_chew_vosa_example.xml"]

--- a/tests/data/musicxml/test_ignore_invisible_objects.musicxml
+++ b/tests/data/musicxml/test_ignore_invisible_objects.musicxml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Partition sans titre</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Compositeur / Arrangeur</creator>
+    <encoding>
+      <software>MuseScore 4.4.4</software>
+      <encoding-date>2024-12-13</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>4</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>none</stem>
+        <notehead>none</notehead>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>none</stem>
+        <notehead>none</notehead>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>none</stem>
+        <notehead>none</notehead>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>none</stem>
+        <notehead>none</notehead>
+        <staff>1</staff>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        </note>
+      <backup>
+        <duration>16</duration>
+        </backup>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>none</stem>
+        <notehead>none</notehead>
+        <staff>2</staff>
+        </note>
+      <note print-object="no">
+        <rest/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+        </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>2</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <accidental>flat</accidental>
+        <stem>up</stem>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -15,6 +15,7 @@ from tests import (
     MUSICXML_UNFOLD_COMPLEX,
     MUSICXML_UNFOLD_VOLTA,
     MUSICXML_UNFOLD_DACAPO,
+    MUSICXML_IGNORE_INVISIBLE_OBJECTS,
 )
 
 from partitura import load_musicxml, save_musicxml
@@ -250,6 +251,29 @@ class TestMusicXML(unittest.TestCase):
 
         self.assertTrue(score.work_title == test_work_title)
         self.assertTrue(score.work_number == test_work_number)
+
+    def test_import_ignore_invisible_objects(self):
+        score_w_invisible = load_musicxml(MUSICXML_IGNORE_INVISIBLE_OBJECTS[0])[0]
+        score_wo_invisible = load_musicxml(MUSICXML_IGNORE_INVISIBLE_OBJECTS[0], ignore_invisible_objects=True)[0]
+
+        score_w_invisible_objs = set(map(str, score_w_invisible.iter_all()))
+        score_wo_invisible_objs = set(map(str, score_wo_invisible.iter_all()))
+
+        self.assertTrue(score_wo_invisible_objs.issubset(score_w_invisible_objs))
+
+        diff = score_w_invisible_objs - score_wo_invisible_objs
+        invisible_objects = {
+            "4--8 Note id=None voice=5 staff=2 type=quarter pitch=D3",
+            "8--12 Rest id=None voice=5 staff=2 type=quarter",
+            "12--13 Note id=None voice=2 staff=1 type=16th pitch=C4",
+            "13--14 Note id=None voice=2 staff=1 type=16th pitch=D4",
+            "14--15 Note id=None voice=2 staff=1 type=16th pitch=C4",
+            "15--16 Note id=None voice=2 staff=1 type=16th pitch=D4",
+            "12--16 Beam",
+        }
+        self.assertEqual(diff, invisible_objects)
+
+
 
 
 def make_part_slur():


### PR DESCRIPTION
As explained in #395, it can sometimes be useful to parse a score only with information available to a human, i.e. visible information. MusicXML allow some elements to be invisible with the attribute `print-object` that can be set to `"yes"` or `"no"`.

This PR simply add a new parameter `ignore_invisible_objects` to the function `load_musicxml`, defaulting to `False` for old behavior. When set to `True`, the loop over all elements in a measure will first check if the element has an attribute `print-object` set to `"no"`, and if so, continue to the next loop without adding the object to the score (for `note` objects, I had to update the position with the duration anyway to avoid errors with backups when notes were not added to the part, I don't know if this can cause issues downstream?).

Note: Initially, I wanted to fully parse the `print-object` attribute, and adding it to all objects supporting it, but it turns out it is a bit more complex than I thought. You need to filter objects that do support it, and maybe use some sort of `CanBeInvisible` mixin to avoid duplicated code, then handle the attribute parsing logic in all the relative `_handle_*object*` when parsing the XML, probably resulting in duplicated code without some sort of refactoring somewhere. Additionally, we would need to also implement the export logic. This PR is way simpler, simply filtering invisible object at import-time.