### PR TITLE
Sort exported notes by step when same `midi_pitch`

### DIFF
--- a/partitura/io/exportmusicxml.py
+++ b/partitura/io/exportmusicxml.py
@@ -417,9 +417,10 @@ def linearize_segment_contents(part, start, end, state):
 
     for voice in sorted(notes_by_voice.keys()):
         voice_notes = notes_by_voice[voice]
-        # sort by pitch
+        # sort by pitch (then step in case of enharmonic notes)
         voice_notes.sort(
-            key=lambda n: n.midi_pitch if hasattr(n, "midi_pitch") else -1, reverse=True
+            key=lambda n: (n.midi_pitch, n.step) if hasattr(n, "midi_pitch") else (-1, ""),
+            reverse=True,
         )
         # grace notes should precede other notes at the same onset
         voice_notes.sort(key=lambda n: not isinstance(n, score.GraceNote))


### PR DESCRIPTION
In MusicXML export, the notes are currently sorted using their `midi_pitch` attribute. However, this can lead to inconsistent exports when the score contains notes that are [enharmonic equivalents](https://en.wikipedia.org/wiki/Enharmonic_equivalence) (such as D# and Eb, or B# and C), as the export will differ depending on the order the user inserts the notes in the `Part` object:
```py
score.add(pt.score.Note("C", 4, 0), start=0, end=1)  # midi_pitch=60
score.add(pt.score.Note("B", 3, 1), start=0, end=1)  # midi_pitch=60
# will result in a different file than
score.add(pt.score.Note("B", 3, 1), start=0, end=1)  # midi_pitch=60
score.add(pt.score.Note("C", 4, 0), start=0, end=1)  # midi_pitch=60
```

This PR simply adds the step as a second key for the sorting. Therefore, notes are first sorted by `midi_pitch`, and when they are enharmonic equivalents they are sorted by `step`, so that the export file is consistent no matter the order the notes are added to the score.

This will solve a potential issue raised in the second message of #406.