### PR TITLE
option to to force new segments in `add_segments`

### DIFF
--- a/partitura/score.py
+++ b/partitura/score.py
@@ -4427,7 +4427,7 @@ class Segment(TimedObject):
         self.info = info
 
 
-def add_segments(part):
+def add_segments(part, force_new = False):
     """
     Add segment objects to a part based on repetition and capo/fine/coda/segno directions.
 
@@ -4436,9 +4436,14 @@ def add_segments(part):
     part: part
         A score part
     """
-    if len([seg for seg in part.iter_all(Segment)]) > 0:
+    existing_segments = [seg for seg in part.iter_all(Segment)]
+    if len(existing_segments) > 0:
         # only add segments if no segments exist
-        pass
+        if force_new:
+            for seg in existing_segments:
+                part.remove(seg)
+        else:
+            pass
     else:
         boundaries = defaultdict(dict)
         destinations = defaultdict(list)
@@ -5004,7 +5009,7 @@ def get_paths(part, no_repeats=False, all_repeats=False, ignore_leap_info=True):
     segments = get_segments(part)
     paths = list()
     unfold_paths(
-        Path(["A"], segments, no_repeats=no_repeats, all_repeats=all_repeats),
+        Path([chr(65)], segments, no_repeats=no_repeats, all_repeats=all_repeats),
         paths,
         ignore_leap_info=ignore_leap_info,
     )


### PR DESCRIPTION
 `add_segments` used to do nothing when segments are present, but several unfolding methods read and overwrite segment attributes in place, which renders them unusable for further unfolding/processing. now one can start from scratch using the flag `force_new` in `add_segments` to get freshly initialized segments. the default behavior doesn't change.