### PR TITLE
Add optional attributes to tuplets related to their time modification

### DIFF
--- a/partitura/io/exportmusicxml.py
+++ b/partitura/io/exportmusicxml.py
@@ -227,9 +227,21 @@ def make_note_el(note, dur, voice, counter, n_of_staves):
         else:
             del counter[tuplet_key]
 
-        notations.append(
-            etree.Element("tuplet", number="{}".format(number), type="start")
-        )
+        tuplet_e = etree.Element("tuplet", number="{}".format(number), type="start")
+        if tuplet.actual_notes is not None and tuplet.normal_notes is not None and tuplet.type is not None:
+            # tuplet-actual tag
+            tuplet_actual_e = etree.SubElement(tuplet_e, "tuplet-actual")
+            tuplet_actual_notes_e = etree.SubElement(tuplet_actual_e, "tuplet-number")
+            tuplet_actual_notes_e.text = str(tuplet.actual_notes)
+            tuplet_actual_type_e = etree.SubElement(tuplet_actual_e, "tuplet-type")
+            tuplet_actual_type_e.text = str(tuplet.type)
+            # tuplet-normal tag
+            tuplet_normal_e = etree.SubElement(tuplet_e, "tuplet-normal")
+            tuplet_normal_notes_e = etree.SubElement(tuplet_normal_e, "tuplet-number")
+            tuplet_normal_notes_e.text = str(tuplet.normal_notes)
+            tuplet_normal_type_e = etree.SubElement(tuplet_normal_e, "tuplet-type")
+            tuplet_normal_type_e.text = str(tuplet.type)
+        notations.append(tuplet_e)
 
     if notations:
         notations_e = etree.SubElement(note_e, "notations")

--- a/partitura/io/exportmusicxml.py
+++ b/partitura/io/exportmusicxml.py
@@ -228,19 +228,24 @@ def make_note_el(note, dur, voice, counter, n_of_staves):
             del counter[tuplet_key]
 
         tuplet_e = etree.Element("tuplet", number="{}".format(number), type="start")
-        if tuplet.actual_notes is not None and tuplet.normal_notes is not None and tuplet.type is not None:
+        if (
+            tuplet.actual_notes is not None
+            and tuplet.normal_notes is not None
+            and tuplet.actual_type is not None
+            and tuplet.normal_type is not None
+        ):
             # tuplet-actual tag
             tuplet_actual_e = etree.SubElement(tuplet_e, "tuplet-actual")
             tuplet_actual_notes_e = etree.SubElement(tuplet_actual_e, "tuplet-number")
             tuplet_actual_notes_e.text = str(tuplet.actual_notes)
             tuplet_actual_type_e = etree.SubElement(tuplet_actual_e, "tuplet-type")
-            tuplet_actual_type_e.text = str(tuplet.type)
+            tuplet_actual_type_e.text = str(tuplet.actual_type)
             # tuplet-normal tag
             tuplet_normal_e = etree.SubElement(tuplet_e, "tuplet-normal")
             tuplet_normal_notes_e = etree.SubElement(tuplet_normal_e, "tuplet-number")
             tuplet_normal_notes_e.text = str(tuplet.normal_notes)
             tuplet_normal_type_e = etree.SubElement(tuplet_normal_e, "tuplet-type")
-            tuplet_normal_type_e.text = str(tuplet.type)
+            tuplet_normal_type_e.text = str(tuplet.normal_type)
         notations.append(tuplet_e)
 
     if notations:

--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -1492,36 +1492,41 @@ def handle_tuplets(notations, ongoing, note):
                 tuplet_actual_type = get_value_from_tag(tuplet_actual, "tuplet-type", str)
                 tuplet_normal_notes = get_value_from_tag(tuplet_normal, "tuplet-number", int)
                 tuplet_normal_type = get_value_from_tag(tuplet_normal, "tuplet-type", str)
-                # Types should always be the same I think?
-                assert tuplet_actual_type == tuplet_normal_type, "Tuplet types are not the same"
-                tuplet_type = tuplet_actual_type
             # If no information, try to infer it from the note
             else:
                 tuplet_actual_notes = note.symbolic_duration.get("actual_notes", None)
                 tuplet_normal_notes = note.symbolic_duration.get("normal_notes", None)
-                tuplet_type = note.symbolic_duration.get("type", None)
+                tuplet_actual_type = note.symbolic_duration.get("type", None)
+                tuplet_normal_type = tuplet_actual_type
 
             # If anyone of the attributes is not set, we set them all to None as we can't really
             # do anything useful with only partial information about the tuplet
-            if None in (tuplet_actual_notes, tuplet_normal_notes, tuplet_type):
+            if None in (tuplet_actual_notes, tuplet_normal_notes, tuplet_actual_type, tuplet_normal_type):
                 tuplet_actual_notes = None
                 tuplet_normal_notes = None
-                tuplet_type = None
-
+                tuplet_actual_type = None
+                tuplet_normal_type = None
 
             # check if we have a stopped_tuplet in ongoing that corresponds to
             # this start
             tuplet = ongoing.pop(stop_tuplet_key, None)
 
             if tuplet is None:
-                tuplet = score.Tuplet(note, actual_notes=tuplet_actual_notes, normal_notes=tuplet_normal_notes, type=tuplet_type)
+                tuplet = score.Tuplet(
+                    note,
+                    actual_notes=tuplet_actual_notes,
+                    normal_notes=tuplet_normal_notes,
+                    actual_type=tuplet_actual_type,
+                    normal_type=tuplet_normal_type,
+                )
                 ongoing[start_tuplet_key] = tuplet
 
             else:
                 tuplet.start_note = note
                 tuplet.actual_notes = tuplet_actual_notes
                 tuplet.normal_notes = tuplet_normal_notes
-                tuplet.type = tuplet_type
+                tuplet.actual_type = tuplet_actual_type
+                tuplet.normal_type = tuplet_normal_type
 
             starting_tuplets.append(tuplet)
 

--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -698,7 +698,10 @@ def _handle_harmony(e, position, part):
         text = e.find("function").text
         if text is not None:
             if "|" in text:
-                text, cadence_annotation = text.split("|")
+                text = text.split("|")
+                if len(text) > 2:
+                    warnings.warn(f"Ignoring multiple cadence annotations {text[2:]}", stacklevel=2)
+                text, cadence_annotation = text[0], text[1]
                 part.add(score.Cadence(cadence_annotation), position)
             part.add(score.RomanNumeral(text), position)
     elif e.find("kind") is not None and e.find("root") is not None:

--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -1452,19 +1452,15 @@ def handle_tuplets(notations, ongoing, note):
                 # Types should always be the same I think?
                 assert tuplet_actual_type == tuplet_normal_type, "Tuplet types are not the same"
                 tuplet_type = tuplet_actual_type
-
             # If no information, try to infer it from the note
-            elif (
-                "actual_notes" in note.symbolic_duration
-                and "normal_notes" in note.symbolic_duration
-                and "type" in note.symbolic_duration
-                ):
-                    tuplet_actual_notes = note.symbolic_duration["actual_notes"]
-                    tuplet_normal_notes = note.symbolic_duration["normal_notes"]
-                    tuplet_type = note.symbolic_duration["type"]
-
-            # If no information is present in the XML or the note, then set to None
             else:
+                tuplet_actual_notes = note.symbolic_duration.get("actual_notes", None)
+                tuplet_normal_notes = note.symbolic_duration.get("normal_notes", None)
+                tuplet_type = note.symbolic_duration.get("type", None)
+
+            # If anyone of the attributes is not set, we set them all to None as we can't really
+            # do anything useful with only partial information about the tuplet
+            if None in (tuplet_actual_notes, tuplet_normal_notes, tuplet_type):
                 tuplet_actual_notes = None
                 tuplet_normal_notes = None
                 tuplet_type = None

--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -1445,10 +1445,10 @@ def handle_tuplets(notations, ongoing, note):
             tuplet_actual = tuplet_e.find("tuplet-actual")
             tuplet_normal = tuplet_e.find("tuplet-normal")
             if tuplet_actual is not None and tuplet_normal is not None:
-                tuplet_actual_notes = int(tuplet_actual.find("tuplet-number").text)
-                tuplet_actual_type = tuplet_actual.find("tuplet-type").text
-                tuplet_normal_notes = int(tuplet_normal.find("tuplet-number").text)
-                tuplet_normal_type = tuplet_normal.find("tuplet-type").text
+                tuplet_actual_notes = get_value_from_tag(tuplet_actual, "tuplet-number", int)
+                tuplet_actual_type = get_value_from_tag(tuplet_actual, "tuplet-type", str)
+                tuplet_normal_notes = get_value_from_tag(tuplet_normal, "tuplet-number", int)
+                tuplet_normal_type = get_value_from_tag(tuplet_normal, "tuplet-type", str)
                 # Types should always be the same I think?
                 assert tuplet_actual_type == tuplet_normal_type, "Tuplet types are not the same"
                 tuplet_type = tuplet_actual_type

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -11,6 +11,7 @@ are registered in terms of their start and end times.
 from copy import copy, deepcopy
 from collections import defaultdict
 from collections.abc import Iterable
+from fractions import Fraction
 from numbers import Number
 from partitura.utils.globals import (
     MUSICAL_BEATS,
@@ -2401,12 +2402,15 @@ class Tuplet(TimedObject):
 
     """
 
-    def __init__(self, start_note=None, end_note=None):
+    def __init__(self, start_note=None, end_note=None, actual_notes=None, normal_notes=None, type=None):
         super().__init__()
         self._start_note = None
         self._end_note = None
         self.start_note = start_note
         self.end_note = end_note
+        self.actual_notes = actual_notes
+        self.normal_notes = normal_notes
+        self.type = type
         # maintain a list of attributes to update when cloning this instance
         self._ref_attrs.extend(["start_note", "end_note"])
 
@@ -2444,10 +2448,17 @@ class Tuplet(TimedObject):
             note.tuplet_stops.append(self)
         self._end_note = note
 
+    @property
+    def duration_multipler(self) -> Fraction:
+        return Fraction(self.normal_notes, self.actual_notes)
+
     def __str__(self):
+        n_actual = "" if self.actual_notes is None else "actual_notes={}".format(self.actual_notes)
+        n_normal = "" if self.normal_notes is None else "normal_notes={}".format(self.normal_notes)
+        type_ = "" if self.type is None else "type={}".format(self.type)
         start = "" if self.start_note is None else "start={}".format(self.start_note.id)
         end = "" if self.end_note is None else "end={}".format(self.end_note.id)
-        return " ".join((super().__str__(), start, end)).strip()
+        return " ".join((super().__str__(), start, end, n_actual, n_normal, type_)).strip()
 
 
 class Repeat(TimedObject):

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -2449,7 +2449,14 @@ class Tuplet(TimedObject):
         self._end_note = note
 
     @property
-    def duration_multipler(self) -> Fraction:
+    def duration_multiplier(self) -> Fraction:
+        """Ratio by which the durations are scaled with this tuplet, as a python Fraction object.
+        This property is similar to `.tupletMultiplier` in music21:
+        https://www.music21.org/music21docs/moduleReference/moduleDuration.html#music21.duration.Tuplet.tupletMultiplier
+
+        For example, in a triplet of eighth notes, each eighth note would have a duration of
+        duration_multiplier * normal_eighth_duration = 2/3 * normal_eighth_duration
+        """
         return Fraction(self.normal_notes, self.actual_notes)
 
     def __str__(self):

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -17,6 +17,7 @@ from partitura.utils.globals import (
     MUSICAL_BEATS,
     INTERVALCLASSES,
     INTERVAL_TO_SEMITONES,
+    LABEL_DURS,
 )
 import warnings, sys
 import numpy as np
@@ -2402,7 +2403,15 @@ class Tuplet(TimedObject):
 
     """
 
-    def __init__(self, start_note=None, end_note=None, actual_notes=None, normal_notes=None, type=None):
+    def __init__(
+            self,
+            start_note=None,
+            end_note=None,
+            actual_notes=None,
+            normal_notes=None,
+            actual_type=None,
+            normal_type=None
+    ):
         super().__init__()
         self._start_note = None
         self._end_note = None
@@ -2410,7 +2419,8 @@ class Tuplet(TimedObject):
         self.end_note = end_note
         self.actual_notes = actual_notes
         self.normal_notes = normal_notes
-        self.type = type
+        self.actual_type = actual_type
+        self.normal_type = normal_type
         # maintain a list of attributes to update when cloning this instance
         self._ref_attrs.extend(["start_note", "end_note"])
 
@@ -2457,15 +2467,25 @@ class Tuplet(TimedObject):
         For example, in a triplet of eighth notes, each eighth note would have a duration of
         duration_multiplier * normal_eighth_duration = 2/3 * normal_eighth_duration
         """
-        return Fraction(self.normal_notes, self.actual_notes)
+        if self.actual_type == self.normal_type:
+            return Fraction(self.normal_notes, self.actual_notes)
+        else:
+            # In that case, we need to convert the normal_type into the actual_type, therefore
+            # adapting normal_notes
+            actual_dur = Fraction(LABEL_DURS[self.actual_type])
+            normal_dur = Fraction(LABEL_DURS[self.normal_type])
+            return Fraction(self.normal_notes, self.actual_notes) * normal_dur / actual_dur
+
+
 
     def __str__(self):
         n_actual = "" if self.actual_notes is None else "actual_notes={}".format(self.actual_notes)
         n_normal = "" if self.normal_notes is None else "normal_notes={}".format(self.normal_notes)
-        type_ = "" if self.type is None else "type={}".format(self.type)
+        t_actual = "" if self.actual_type is None else "actual_type={}".format(self.actual_type)
+        t_normal = "" if self.normal_type is None else "normal_type={}".format(self.normal_type)
         start = "" if self.start_note is None else "start={}".format(self.start_note.id)
         end = "" if self.end_note is None else "end={}".format(self.end_note.id)
-        return " ".join((super().__str__(), start, end, n_actual, n_normal, type_)).strip()
+        return " ".join((super().__str__(), start, end, n_actual, n_normal, t_actual, t_normal)).strip()
 
 
 class Repeat(TimedObject):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -45,6 +45,10 @@ MUSICXML_UNFOLD_TESTPAIRS = [
         )
     ]
 ]
+MUSICXML_TUPLET_ATTRIBUTES_TESTFILES = [
+    os.path.join(MUSICXML_PATH, fn)
+    for fn in ["test_tuplet_attributes.musicxml"]
+]
 
 MUSICXML_UNFOLD_COMPLEX = [
     (

--- a/tests/data/musicxml/test_tuplet_attributes.musicxml
+++ b/tests/data/musicxml/test_tuplet_attributes.musicxml
@@ -8,7 +8,7 @@
     <creator type="composer">Compositeur / Arrangeur</creator>
     <encoding>
       <software>MuseScore 4.4.4</software>
-      <encoding-date>2025-01-17</encoding-date>
+      <encoding-date>2025-01-22</encoding-date>
       <supports element="accidental" type="yes"/>
       <supports element="beam" type="yes"/>
       <supports element="print" attribute="new-page" type="no"/>
@@ -36,12 +36,12 @@
   <part id="P1">
     <measure number="1">
       <attributes>
-        <divisions>60</divisions>
+        <divisions>180</divisions>
         <key>
           <fifths>0</fifths>
           </key>
         <time>
-          <beats>3</beats>
+          <beats>5</beats>
           <beat-type>4</beat-type>
           </time>
         <clef>
@@ -54,7 +54,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>60</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
@@ -64,15 +64,15 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         <notations>
-          <tuplet type="start" bracket="no"/>
+          <tuplet type="start" bracket="yes"/>
           </notations>
         </note>
       <note>
         <pitch>
-          <step>E</step>
+          <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>60</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
@@ -84,10 +84,10 @@
         </note>
       <note>
         <pitch>
-          <step>G</step>
+          <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>60</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
@@ -105,17 +105,18 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>24</duration>
+        <duration>72</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>5</actual-notes>
           <normal-notes>4</normal-notes>
+          <normal-type>eighth</normal-type>
           </time-modification>
         <stem>up</stem>
         <beam number="1">begin</beam>
         <notations>
-          <tuplet type="start" number="1" bracket="no"/>
+          <tuplet type="start" number="1" bracket="yes"/>
           </notations>
         </note>
       <note>
@@ -123,12 +124,13 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>24</duration>
+        <duration>72</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>5</actual-notes>
           <normal-notes>4</normal-notes>
+          <normal-type>eighth</normal-type>
           </time-modification>
         <stem>up</stem>
         <beam number="1">continue</beam>
@@ -138,7 +140,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>8</duration>
+        <duration>24</duration>
         <voice>1</voice>
         <type>16th</type>
         <time-modification>
@@ -149,7 +151,7 @@
         <beam number="1">continue</beam>
         <beam number="2">begin</beam>
         <notations>
-          <tuplet type="start" number="2" bracket="yes" placement="below">
+          <tuplet type="start" number="2" bracket="yes" show-number="both" placement="below">
             <tuplet-actual>
               <tuplet-number>3</tuplet-number>
               <tuplet-type>16th</tuplet-type>
@@ -166,7 +168,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>8</duration>
+        <duration>24</duration>
         <voice>1</voice>
         <type>16th</type>
         <time-modification>
@@ -182,7 +184,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>8</duration>
+        <duration>24</duration>
         <voice>1</voice>
         <type>16th</type>
         <time-modification>
@@ -201,12 +203,13 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>24</duration>
+        <duration>72</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>5</actual-notes>
           <normal-notes>4</normal-notes>
+          <normal-type>eighth</normal-type>
           </time-modification>
         <stem>up</stem>
         <beam number="1">continue</beam>
@@ -216,17 +219,177 @@
           <step>B</step>
           <octave>4</octave>
           </pitch>
-        <duration>24</duration>
+        <duration>72</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
           <actual-notes>5</actual-notes>
           <normal-notes>4</normal-notes>
+          <normal-type>eighth</normal-type>
           </time-modification>
         <stem>up</stem>
         <beam number="1">end</beam>
         <notations>
           <tuplet type="stop" number="1"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>40</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>9</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="yes">
+            <tuplet-actual>
+              <tuplet-number>9</tuplet-number>
+              <tuplet-type>16th</tuplet-type>
+              </tuplet-actual>
+            <tuplet-normal>
+              <tuplet-number>2</tuplet-number>
+              <tuplet-type>quarter</tuplet-type>
+              </tuplet-normal>
+            </tuplet>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>40</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>9</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>40</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>9</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>40</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>9</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>40</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>9</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>40</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>9</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>40</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>9</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>40</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>9</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>40</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>9</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        <notations>
+          <tuplet type="stop"/>
           </notations>
         </note>
       </measure>
@@ -242,7 +405,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>45</duration>
+        <duration>135</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
@@ -252,15 +415,15 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         <notations>
-          <tuplet type="start" bracket="no"/>
+          <tuplet type="start" bracket="yes"/>
           </notations>
         </note>
       <note>
         <pitch>
-          <step>G</step>
+          <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>45</duration>
+        <duration>135</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
@@ -278,7 +441,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>18</duration>
+        <duration>54</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
@@ -288,7 +451,7 @@
         <stem>up</stem>
         <beam number="1">begin</beam>
         <notations>
-          <tuplet type="start" bracket="no" show-number="both"/>
+          <tuplet type="start" bracket="yes" show-number="both"/>
           </notations>
         </note>
       <note>
@@ -296,7 +459,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>18</duration>
+        <duration>54</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
@@ -311,7 +474,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>18</duration>
+        <duration>54</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
@@ -326,7 +489,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>18</duration>
+        <duration>54</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>
@@ -341,7 +504,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>18</duration>
+        <duration>54</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>

--- a/tests/data/musicxml/test_tuplet_attributes.musicxml
+++ b/tests/data/musicxml/test_tuplet_attributes.musicxml
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Partition sans titre</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Compositeur / Arrangeur</creator>
+    <encoding>
+      <software>MuseScore 4.4.4</software>
+      <encoding-date>2025-01-17</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>60</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>3</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>20</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>20</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>20</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>24</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" number="1" bracket="no"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>24</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>15</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">begin</beam>
+        <notations>
+          <tuplet type="start" number="2" bracket="yes" placement="below">
+            <tuplet-actual>
+              <tuplet-number>3</tuplet-number>
+              <tuplet-type>16th</tuplet-type>
+              </tuplet-actual>
+            <tuplet-normal>
+              <tuplet-number>2</tuplet-number>
+              <tuplet-type>16th</tuplet-type>
+              </tuplet-normal>
+            </tuplet>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>15</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <time-modification>
+          <actual-notes>15</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">end</beam>
+        <notations>
+          <tuplet type="stop" number="2"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>24</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>24</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>4</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop" number="1"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="2">
+      <attributes>
+        <time>
+          <beats>6</beats>
+          <beat-type>8</beat-type>
+          </time>
+        </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>45</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>2</actual-notes>
+          <normal-notes>3</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>45</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>2</actual-notes>
+          <normal-notes>3</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>18</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>3</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tuplet type="start" bracket="no" show-number="both"/>
+          </notations>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>18</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>3</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>18</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>3</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>18</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>3</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>18</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>3</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -7,6 +7,7 @@ This module contains test functions for MusicXML import and export.
 import logging
 import unittest
 from tempfile import TemporaryFile
+from fractions import Fraction
 
 from tests import (
     MUSICXML_IMPORT_EXPORT_TESTFILES,
@@ -223,17 +224,21 @@ class TestMusicXML(unittest.TestCase):
     def test_tuplet_attributes(self):
         part = load_musicxml(MUSICXML_TUPLET_ATTRIBUTES_TESTFILES[0])[0]
         tuplets = list(part.iter_all(cls=score.Tuplet))
+        # Each tuple consists of (actual_notes, normal_notes, type, note_type, duration_multiplier)
         real_values = [
-            (3, 2, "eighth"),
-            (5, 4, "eighth"),
-            (3, 2, "16th"),
-            (2, 3, "eighth"),
-            (5, 3, "eighth"),
+            (3, 2, "eighth", "eighth", Fraction(2, 3)),
+            (5, 4, "eighth", "eighth", Fraction(4, 5)),
+            (3, 2, "16th", "16th", Fraction(2, 3)),
+            (9, 2, "16th", "quarter", Fraction(8, 9)),
+            (2, 3, "eighth", "eighth", Fraction(3, 2)),
+            (5, 3, "eighth", "eighth", Fraction(3, 5)),
         ]
-        for tuplet, (actual, normal, note_type) in zip(tuplets, real_values):
-            self.assertEqual(tuplet.actual_notes, actual)
-            self.assertEqual(tuplet.normal_notes, normal)
-            self.assertEqual(tuplet.type, note_type)
+        for tuplet, (n_actual, n_normal, t_actual, t_normal, dur_mult) in zip(tuplets, real_values):
+            self.assertEqual(tuplet.actual_notes, n_actual)
+            self.assertEqual(tuplet.normal_notes, n_normal)
+            self.assertEqual(tuplet.actual_type, t_actual)
+            self.assertEqual(tuplet.normal_type, t_normal)
+            self.assertEqual(tuplet.duration_multiplier, dur_mult)
 
     def _pretty_export_import_pretty_test(self, part1):
         # pretty print the part

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -11,6 +11,7 @@ from tempfile import TemporaryFile
 from tests import (
     MUSICXML_IMPORT_EXPORT_TESTFILES,
     MUSICXML_SCORE_OBJECT_TESTFILES,
+    MUSICXML_TUPLET_ATTRIBUTES_TESTFILES,
     MUSICXML_UNFOLD_TESTPAIRS,
     MUSICXML_UNFOLD_COMPLEX,
     MUSICXML_UNFOLD_VOLTA,
@@ -216,6 +217,21 @@ class TestMusicXML(unittest.TestCase):
         # test if stem direction is imported correctly for the first note of test_note_ties.xml
         part = load_musicxml(MUSICXML_IMPORT_EXPORT_TESTFILES[0])[0]
         self.assertEqual(part.notes_tied[0].stem_direction, "up")
+
+    def test_tuplet_attributes(self):
+        part = load_musicxml(MUSICXML_TUPLET_ATTRIBUTES_TESTFILES[0])[0]
+        tuplets = list(part.iter_all(cls=score.Tuplet))
+        real_values = [
+            (3, 2, "eighth"),
+            (5, 4, "eighth"),
+            (3, 2, "16th"),
+            (2, 3, "eighth"),
+            (5, 3, "eighth"),
+        ]
+        for tuplet, (actual, normal, note_type) in zip(tuplets, real_values):
+            self.assertEqual(tuplet.actual_notes, actual)
+            self.assertEqual(tuplet.normal_notes, normal)
+            self.assertEqual(tuplet.type, note_type)
 
     def _pretty_export_import_pretty_test(self, part1):
         # pretty print the part


### PR DESCRIPTION
As I explained in #405, I thought that tuplets objects were missing some information about the rhythmic modifications they induce (actual notes, normal notes and type). In MusicXML scores, tuplets elements *can* contain this information in [`<tuplet-actual>`](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/tuplet-actual) and [`<tuplet-normal>`](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/tuplet-normal) tags, but usually, they do not need to be specified and can be inferred from the `<time-modification>` tags of notes. Actually, MuseScore only exports such tags in case of nested tuplets as `<time-modification>` tags result from the multiplication of the different nested ratio.

Currently, Partitura does not parse those tags, and therefore some information is lost in case of nested tuplets. Even in the case of simple single-level tuplets, I feel that this information should be accessible at the `Tuplet` object level, in addition to the note level.

This PR allows exactly that, by adding optional `actual_notes`, `normal_notes` and `type` attributes, that are parsed from the MusicXML `<tuplet-actual/normal>` tags if present, and otherwise inferred from the first note of the tuplet.

This also adds a property `duration_multiplier` to the `Tuplet` similarly to what music21 proposes (which is simply `normal_notes/actual_notes`).

I also implemented it at export time, always outputting the tags `<tuplet-actual/normal>` no matter if they are absolutely needed or only optional, I don't think that it could cause any issue?