### PR TITLE
Fix Issue #414

### DIFF
--- a/partitura/score.py
+++ b/partitura/score.py
@@ -3396,12 +3396,43 @@ class NoteTechnicalNotation(object):
 
 
 class Fingering(NoteTechnicalNotation):
-    def __init__(self, fingering: int) -> None:
+    """
+    This object represents fingering. For now, it supports attributes
+    present in MusicXML:
+
+    https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/fingering/
+
+    Parameters
+    ----------
+    fingering : Optional[int]
+        Fingering information. Can be None (usually the result of incorrect parsing of fingering).
+
+    is_substitution: bool
+        Whether this fingering is a substitution in the middle of a note. Default is False
+    
+    is_alternate: bool
+        Whether this fingering is an alternative fingering. Default is False
+
+    placement: str
+        Placement of the fingering (above or below a note)
+    """
+
+    def __init__(
+        self,
+        fingering: Optional[int],
+        is_substitution: bool = False,
+        placement: Optional[str] = None,
+        is_alternate: bool = False,
+    ) -> None:
         super().__init__(
             type="fingering",
             info=fingering,
         )
         self.fingering = fingering
+        self.is_alternate = is_alternate
+        self.alternative_fingering = []
+        self.is_substitution = is_substitution
+        self.placement = placement
 
 
 class PartGroup(object):

--- a/partitura/utils/misc.py
+++ b/partitura/utils/misc.py
@@ -8,8 +8,9 @@ import os
 import warnings
 from urllib.request import urlopen
 from shutil import copyfileobj
+import re
 
-from typing import Union, Callable, Dict, Any, Iterable, Optional
+from typing import Union, Callable, Dict, Any, Iterable, Optional, List
 
 import numpy as np
 
@@ -280,3 +281,23 @@ def download_file(
     """
     with urlopen(url) as in_stream, open(out, "wb") as out_file:
         copyfileobj(in_stream, out_file)
+
+
+def parse_ints(input_string: str) -> List[int]:
+    """
+    Parse all numbers from a given string where numbers are separated by spaces or tabs.
+
+    Parameters
+    ----------
+    input_string : str
+        The input string containing numbers separated by spaces or tabs.
+
+    Returns
+    -------
+    List[int]
+        A list of integers extracted from the input string.
+    """
+    # Regular expression to match numbers
+    pattern = r'\d+'
+    # Find all matches and convert them to integers
+    return list(map(int, re.findall(pattern, input_string)))


### PR DESCRIPTION
This pull request fixes issue #415.

Some MusicXML files have incorrectly formatted fingering information (the value of the attribute `<fingering>`  should be an integer, but some files include other strings such as `4_1`).

In the current solution, parsing these strings would only take the first value and would ignore subsequent values. Otherwise, if the string cannot be parsed, the fingering would be set to None, instead of raising an error.