### PR TITLE
Replaced deprecated scipy derivative

### DIFF
--- a/partitura/musicanalysis/performance_codec.py
+++ b/partitura/musicanalysis/performance_codec.py
@@ -14,9 +14,9 @@ from partitura.score import Part, ScoreLike
 from partitura.performance import PerformedPart, PerformanceLike
 from partitura.musicanalysis import note_features
 from partitura.utils.misc import deprecated_alias
-from partitura.utils.generic import interp1d, monotonize_times
+from partitura.utils.generic import interp1d, monotonize_times, first_order_derivative
 from partitura.utils.music import ensure_notearray
-from scipy.misc import derivative
+
 
 __all__ = ["encode_performance", "decode_performance", "to_matched_score"]
 
@@ -595,7 +595,7 @@ def tempo_by_derivative(
     if input_onsets is None:
         input_onsets = unique_s_onsets[:-1]
 
-    tempo_curve = derivative(onset_fun, input_onsets, dx=0.5)
+    tempo_curve = first_order_derivative(onset_fun, input_onsets, dx=0.5)
 
     if return_onset_idxs:
         return tempo_curve, input_onsets, unique_onset_idxs

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -174,6 +174,8 @@ def iter_subclasses(cls, _seen=None):
 def first_order_derivative(func, x0, dx=0.5):
     """
     Compute the first order derivative of a function at a point `x0` using
+    a central difference scheme. This function is an adaptation of the scipy _derivative
+    function, which is no longer available in the public API after version 1.15.
     Parameters
     ----------
     func: callable
@@ -188,8 +190,6 @@ def first_order_derivative(func, x0, dx=0.5):
     np.ndarray
         First order derivative of `func` at `x0`
     """
-    # fixed order
-    n = 1
     # fixed number of points to use, must be odd.
     num_points = 3
     weights = np.array([-1, 0, 1]) / 2.0
@@ -197,7 +197,7 @@ def first_order_derivative(func, x0, dx=0.5):
     ho = num_points >> 1
     for k in range(num_points):
         val += weights[k] * func(x0 + (k - ho) * dx)
-    return val / np.prod((dx,) * n, axis=0)
+    return val / np.prod((dx,), axis=0)
 
 
 class ReplaceRefMixin(object):

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -171,6 +171,35 @@ def iter_subclasses(cls, _seen=None):
                 yield sub
 
 
+def first_order_derivative(func, x0, dx=0.5):
+    """
+    Compute the first order derivative of a function at a point `x0` using
+    Parameters
+    ----------
+    func: callable
+        Function to differentiate
+    x0: np.ndarray
+        Points at which to differentiate
+    dx: float
+        Step size
+
+    Returns
+    -------
+    np.ndarray
+        First order derivative of `func` at `x0`
+    """
+    # fixed order
+    n = 1
+    # fixed number of points to use, must be odd.
+    num_points = 3
+    weights = np.array([-1, 0, 1]) / 2.0
+    val = 0.0
+    ho = num_points >> 1
+    for k in range(num_points):
+        val += weights[k] * func(x0 + (k - ho) * dx)
+    return val / np.prod((dx,) * n, axis=0)
+
+
 class ReplaceRefMixin(object):
     """This class is a utility mixin class to replace references to
     objects with references to other objects. This is functionality is

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -200,7 +200,7 @@ def first_order_derivative(func, x0, dx=0.5):
     ho = num_points >> 1
     for k in range(num_points):
         val += weights[k] * func(x0 + (k - ho) * dx)
-    return val / np.prod((dx,), axis=0)
+    return val / dx
 
 
 class ReplaceRefMixin(object):

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -176,6 +176,9 @@ def first_order_derivative(func, x0, dx=0.5):
     Compute the first order derivative of a function at a point `x0` using
     a central difference scheme. This function is an adaptation of the scipy _derivative
     function, which is no longer available in the public API after version 1.15.
+    More information can be found at:
+    https://github.com/scipy/scipy/blob/v1.7.0/scipy/misc/common.py#L75-L145
+
     Parameters
     ----------
     func: callable


### PR DESCRIPTION
This pull request introduces a new function `first_order_derivative` and replaces the usage of `scipy.misc.derivative` with this new function in the `partitura` package. As of scipy version 1.15 the function  `scipy.misc.derivative` is deprecated. 