### PR TITLE
Allow `iter_all` to iterate over multiple classes

### DIFF
--- a/partitura/score.py
+++ b/partitura/score.py
@@ -1090,8 +1090,8 @@ class Part(object):
 
         Parameters
         ----------
-        cls : class, optional
-            The class of objects to iterate over. If omitted, iterate
+        cls : class or iterable of classes, optional
+            The class (or classes) of objects to iterate over. If omitted, iterate
             over all objects in the part.
         start : :class:`TimePoint`, optional
             The start of the interval to search. If omitted or None,
@@ -1135,12 +1135,21 @@ class Part(object):
             cls = object
             include_subclasses = True
 
+        # If single class passed, convert to list
+        if isinstance(cls, type):
+            cls = [cls]
+
+        if not isinstance(cls, Iterable):
+            raise TypeError("cls should be a class, an iterable of classes, or None")
+
         if mode == "ending":
             for tp in self._points[start_idx:end_idx]:
-                yield from tp.iter_ending(cls, include_subclasses)
+                for c in cls:
+                    yield from tp.iter_ending(c, include_subclasses)
         else:
             for tp in self._points[start_idx:end_idx]:
-                yield from tp.iter_starting(cls, include_subclasses)
+                for c in cls:
+                    yield from tp.iter_starting(c, include_subclasses)
 
     def apply(self):
         """Apply all changes to the timeline for objects like octave Shift."""


### PR DESCRIPTION
Fixes #426.

When iterating over a `Part`'s elements, the user can only provide a single class to filter the output. If they want to get multiple classes, they can either iterate over *all* classes and filter a posteriori, or iterate multiple times over a single class. Those two workarounds are quite slow, so the possibility to iterate over multiple classes in a single pass would be useful.

This PR simply allows the user to pass an iterable to the `cls` parameter of `iter_all`. For example, the following would allow to easily retrieve a list of all key/time signature/clef change over the score (in that order when they are simultaneous), in a single iteration over all time points.
```py
part.iter_all(cls=[TimeSignature, KeySignature, Clef])
```

There are still a couple of things to discuss before merging this, briefly evoked in #426:
- It makes sense that the parameters `start`, `end` and `mode` apply to all classes. However, should the parameter `include_subclasses` apply to all of them? Maybe I could add the possibility to pass either a single boolean (apply to all classes) or an iterable of booleans (apply to indivisual classes, same size as the `cls` iterable).
- What if a user provides `cls=[GenericNote, Note]` with `include_subclasses=True`? (Or even simpler if they provide `cls=[Note, Note]`) Should the iterator return duplicate objects? Or deduplicated objects only? Or raise an error?

I have not added any tests yet, but I can add some, although I'm not sure in which file they would belong. I haven't found any existing test for the function `iter_all`.