### PR TITLE
Support for `<tuplet-dot/>` and `<normal-dot/>` tags when parsing tuplets

### DIFF
--- a/partitura/io/exportmusicxml.py
+++ b/partitura/io/exportmusicxml.py
@@ -242,6 +242,8 @@ def make_note_el(note, dur, voice, counter, n_of_staves):
             tuplet_actual_notes_e.text = str(tuplet.actual_notes)
             tuplet_actual_type_e = etree.SubElement(tuplet_actual_e, "tuplet-type")
             tuplet_actual_type_e.text = str(tuplet.actual_type)
+            for _ in range(tuplet.actual_dots):
+                etree.SubElement(tuplet_actual_e, "tuplet-dot")
             # tuplet-normal tag
             tuplet_normal_e = etree.SubElement(tuplet_e, "tuplet-normal")
             tuplet_normal_notes_e = etree.SubElement(tuplet_normal_e, "tuplet-number")

--- a/partitura/io/exportmusicxml.py
+++ b/partitura/io/exportmusicxml.py
@@ -184,6 +184,8 @@ def make_note_el(note, dur, voice, counter, n_of_staves):
         actual_e.text = str(sym_dur["actual_notes"])
         normal_e = etree.SubElement(time_mod_e, "normal-notes")
         normal_e.text = str(sym_dur["normal_notes"])
+        for _ in range(sym_dur.get("normal_dots", 0)):
+            etree.SubElement(time_mod_e, "normal-dot")
 
     if note.staff is not None:
         if note.staff != 1 or n_of_staves > 1:
@@ -246,6 +248,8 @@ def make_note_el(note, dur, voice, counter, n_of_staves):
             tuplet_normal_notes_e.text = str(tuplet.normal_notes)
             tuplet_normal_type_e = etree.SubElement(tuplet_normal_e, "tuplet-type")
             tuplet_normal_type_e.text = str(tuplet.normal_type)
+            for _ in range(tuplet.normal_dots):
+                etree.SubElement(tuplet_normal_e, "tuplet-dot")
         notations.append(tuplet_e)
 
     if notations:

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -2473,7 +2473,7 @@ class Tuplet(TimedObject):
         """
         if (
             self.actual_type == self.normal_type
-            and self.actual_notes == self.normal_notes
+            and self.actual_dots == self.normal_dots
         ):
             return Fraction(self.normal_notes, self.actual_notes)
         else:

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -2410,6 +2410,7 @@ class Tuplet(TimedObject):
         actual_notes=None,
         normal_notes=None,
         actual_type=None,
+        actual_dots=None,
         normal_type=None,
         normal_dots=None,
     ):
@@ -2422,6 +2423,7 @@ class Tuplet(TimedObject):
         self.normal_notes = normal_notes
         self.actual_type = actual_type
         self.normal_type = normal_type
+        self.actual_dots = actual_dots
         self.normal_dots = normal_dots
         # maintain a list of attributes to update when cloning this instance
         self._ref_attrs.extend(["start_note", "end_note"])
@@ -2469,13 +2471,18 @@ class Tuplet(TimedObject):
         For example, in a triplet of eighth notes, each eighth note would have a duration of
         duration_multiplier * normal_eighth_duration = 2/3 * normal_eighth_duration
         """
-        if self.actual_type == self.normal_type and not self.normal_dots:
+        if (
+            self.actual_type == self.normal_type
+            and self.actual_notes == self.normal_notes
+        ):
             return Fraction(self.normal_notes, self.actual_notes)
         else:
             # In that case, we need to convert the normal_type into the actual_type, therefore
             # adapting normal_notes
             actual_dur = Fraction(LABEL_DURS[self.actual_type])
             normal_dur = Fraction(LABEL_DURS[self.normal_type])
+            for _ in range(self.actual_dots):
+                actual_dur += actual_dur / 2
             for _ in range(self.normal_dots):
                 normal_dur += normal_dur / 2
             return (
@@ -2503,6 +2510,8 @@ class Tuplet(TimedObject):
             if self.normal_type is None
             else "normal_type={}".format(self.normal_type)
         )
+        for _ in range(self.actual_dots):
+            t_actual += "."
         for _ in range(self.normal_dots):
             t_normal += "."
         start = "" if self.start_note is None else "start={}".format(self.start_note.id)

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -2510,10 +2510,12 @@ class Tuplet(TimedObject):
             if self.normal_type is None
             else "normal_type={}".format(self.normal_type)
         )
-        for _ in range(self.actual_dots):
-            t_actual += "."
-        for _ in range(self.normal_dots):
-            t_normal += "."
+        if self.actual_dots:
+            for _ in range(self.actual_dots):
+                t_actual += "."
+        if self.normal_dots:
+            for _ in range(self.normal_dots):
+                t_normal += "."
         start = "" if self.start_note is None else "start={}".format(self.start_note.id)
         end = "" if self.end_note is None else "end={}".format(self.end_note.id)
         return " ".join(

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -2411,6 +2411,7 @@ class Tuplet(TimedObject):
         normal_notes=None,
         actual_type=None,
         normal_type=None,
+        normal_dots=None,
     ):
         super().__init__()
         self._start_note = None
@@ -2421,6 +2422,7 @@ class Tuplet(TimedObject):
         self.normal_notes = normal_notes
         self.actual_type = actual_type
         self.normal_type = normal_type
+        self.normal_dots = normal_dots
         # maintain a list of attributes to update when cloning this instance
         self._ref_attrs.extend(["start_note", "end_note"])
 
@@ -2467,13 +2469,15 @@ class Tuplet(TimedObject):
         For example, in a triplet of eighth notes, each eighth note would have a duration of
         duration_multiplier * normal_eighth_duration = 2/3 * normal_eighth_duration
         """
-        if self.actual_type == self.normal_type:
+        if self.actual_type == self.normal_type and not self.normal_dots:
             return Fraction(self.normal_notes, self.actual_notes)
         else:
             # In that case, we need to convert the normal_type into the actual_type, therefore
             # adapting normal_notes
             actual_dur = Fraction(LABEL_DURS[self.actual_type])
             normal_dur = Fraction(LABEL_DURS[self.normal_type])
+            for _ in range(self.normal_dots):
+                normal_dur += normal_dur / 2
             return (
                 Fraction(self.normal_notes, self.actual_notes) * normal_dur / actual_dur
             )
@@ -2499,6 +2503,8 @@ class Tuplet(TimedObject):
             if self.normal_type is None
             else "normal_type={}".format(self.normal_type)
         )
+        for _ in range(self.normal_dots):
+            t_normal += "."
         start = "" if self.start_note is None else "start={}".format(self.start_note.id)
         end = "" if self.end_note is None else "end={}".format(self.end_note.id)
         return " ".join(

--- a/tests/data/musicxml/test_tuplet_attributes.musicxml
+++ b/tests/data/musicxml/test_tuplet_attributes.musicxml
@@ -8,7 +8,7 @@
     <creator type="composer">Compositeur / Arrangeur</creator>
     <encoding>
       <software>MuseScore 4.4.4</software>
-      <encoding-date>2025-01-22</encoding-date>
+      <encoding-date>2025-02-05</encoding-date>
       <supports element="accidental" type="yes"/>
       <supports element="beam" type="yes"/>
       <supports element="print" attribute="new-page" type="no"/>
@@ -111,7 +111,6 @@
         <time-modification>
           <actual-notes>5</actual-notes>
           <normal-notes>4</normal-notes>
-          <normal-type>eighth</normal-type>
           </time-modification>
         <stem>up</stem>
         <beam number="1">begin</beam>
@@ -130,7 +129,6 @@
         <time-modification>
           <actual-notes>5</actual-notes>
           <normal-notes>4</normal-notes>
-          <normal-type>eighth</normal-type>
           </time-modification>
         <stem>up</stem>
         <beam number="1">continue</beam>
@@ -209,7 +207,6 @@
         <time-modification>
           <actual-notes>5</actual-notes>
           <normal-notes>4</normal-notes>
-          <normal-type>eighth</normal-type>
           </time-modification>
         <stem>up</stem>
         <beam number="1">continue</beam>
@@ -225,7 +222,6 @@
         <time-modification>
           <actual-notes>5</actual-notes>
           <normal-notes>4</normal-notes>
-          <normal-type>eighth</normal-type>
           </time-modification>
         <stem>up</stem>
         <beam number="1">end</beam>
@@ -396,7 +392,7 @@
     <measure number="2">
       <attributes>
         <time>
-          <beats>6</beats>
+          <beats>9</beats>
           <beat-type>8</beat-type>
           </time>
         </attributes>
@@ -446,12 +442,14 @@
         <type>eighth</type>
         <time-modification>
           <actual-notes>5</actual-notes>
-          <normal-notes>3</normal-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>quarter</normal-type>
+          <normal-dot/>
           </time-modification>
         <stem>up</stem>
         <beam number="1">begin</beam>
         <notations>
-          <tuplet type="start" bracket="yes" show-number="both"/>
+          <tuplet type="start" bracket="yes"/>
           </notations>
         </note>
       <note>
@@ -464,55 +462,76 @@
         <type>eighth</type>
         <time-modification>
           <actual-notes>5</actual-notes>
-          <normal-notes>3</normal-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>quarter</normal-type>
+          <normal-dot/>
           </time-modification>
         <stem>up</stem>
-        <beam number="1">continue</beam>
+        <beam number="1">end</beam>
         </note>
       <note>
         <pitch>
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>54</duration>
+        <duration>108</duration>
         <voice>1</voice>
-        <type>eighth</type>
+        <type>quarter</type>
         <time-modification>
           <actual-notes>5</actual-notes>
-          <normal-notes>3</normal-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>quarter</normal-type>
+          <normal-dot/>
           </time-modification>
         <stem>up</stem>
-        <beam number="1">continue</beam>
         </note>
       <note>
         <pitch>
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>54</duration>
+        <duration>108</duration>
         <voice>1</voice>
-        <type>eighth</type>
+        <type>quarter</type>
         <time-modification>
           <actual-notes>5</actual-notes>
-          <normal-notes>3</normal-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>quarter</normal-type>
+          <normal-dot/>
           </time-modification>
         <stem>up</stem>
-        <beam number="1">continue</beam>
         </note>
       <note>
         <pitch>
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>54</duration>
+        <duration>108</duration>
         <voice>1</voice>
-        <type>eighth</type>
+        <type>quarter</type>
         <time-modification>
           <actual-notes>5</actual-notes>
-          <normal-notes>3</normal-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>quarter</normal-type>
+          <normal-dot/>
           </time-modification>
         <stem>up</stem>
-        <beam number="1">end</beam>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>108</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <time-modification>
+          <actual-notes>5</actual-notes>
+          <normal-notes>2</normal-notes>
+          <normal-type>quarter</normal-type>
+          <normal-dot/>
+          </time-modification>
+        <stem>up</stem>
         <notations>
           <tuplet type="stop"/>
           </notations>

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -224,20 +224,26 @@ class TestMusicXML(unittest.TestCase):
     def test_tuplet_attributes(self):
         part = load_musicxml(MUSICXML_TUPLET_ATTRIBUTES_TESTFILES[0])[0]
         tuplets = list(part.iter_all(cls=score.Tuplet))
-        # Each tuple consists of (actual_notes, normal_notes, type, note_type, duration_multiplier)
+        # Each tuple consists of:
+        # (actual_notes, normal_notes, actual_type, normal_type, normal_dots, duration_multiplier)
+        # fmt: off
         real_values = [
-            (3, 2, "eighth", "eighth", Fraction(2, 3)),
-            (5, 4, "eighth", "eighth", Fraction(4, 5)),
-            (3, 2, "16th", "16th", Fraction(2, 3)),
-            (9, 2, "16th", "quarter", Fraction(8, 9)),
-            (2, 3, "eighth", "eighth", Fraction(3, 2)),
-            (5, 3, "eighth", "eighth", Fraction(3, 5)),
+            (3, 2, "eighth", "eighth", 0, Fraction(2, 3)),  # classic 3:2 eighth notes tuplet
+            (5, 4, "eighth", "eighth", 0, Fraction(4, 5)),  # 5:4 eighth notes tuplet
+            (3, 2, "16th", "16th", 0, Fraction(2, 3)),      # 3:2 16th notes tuplet
+            (9, 2, "16th", "quarter", 0, Fraction(8, 9)),   # 9 16th notes against 2 quarter notes
+            (2, 3, "eighth", "eighth", 0, Fraction(3, 2)),  # classic 2:3 duolet
+            (5, 2, "quarter", "quarter", 1, Fraction(3, 5)) # 5 quarter notes in the time of 2 dotted quarter notes
         ]
-        for tuplet, (n_actual, n_normal, t_actual, t_normal, dur_mult) in zip(tuplets, real_values):
+        # fmt: on
+        for tuplet, (n_actual, n_normal, t_actual, t_normal, d_normal, dur_mult) in zip(
+            tuplets, real_values
+        ):
             self.assertEqual(tuplet.actual_notes, n_actual)
             self.assertEqual(tuplet.normal_notes, n_normal)
             self.assertEqual(tuplet.actual_type, t_actual)
             self.assertEqual(tuplet.normal_type, t_normal)
+            self.assertEqual(tuplet.normal_dots, d_normal)
             self.assertEqual(tuplet.duration_multiplier, dur_mult)
 
     def _pretty_export_import_pretty_test(self, part1):

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -225,25 +225,26 @@ class TestMusicXML(unittest.TestCase):
         part = load_musicxml(MUSICXML_TUPLET_ATTRIBUTES_TESTFILES[0])[0]
         tuplets = list(part.iter_all(cls=score.Tuplet))
         # Each tuple consists of:
-        # (actual_notes, normal_notes, actual_type, normal_type, normal_dots, duration_multiplier)
+        # (act_notes, norm_notes, act_type, norm_type, act_dots, norm_dots, dur_mult)
         # fmt: off
         real_values = [
-            (3, 2, "eighth", "eighth", 0, Fraction(2, 3)),   # classic 3:2 eighth notes tuplet
-            (5, 4, "eighth", "eighth", 0, Fraction(4, 5)),   # 5:4 eighth notes tuplet
-            (3, 2, "16th", "16th", 0, Fraction(2, 3)),       # 3:2 16th notes tuplet
-            (9, 2, "16th", "quarter", 0, Fraction(8, 9)),    # 9 16th notes against 2 quarter notes
-            (2, 3, "eighth", "eighth", 0, Fraction(3, 2)),   # classic 2:3 duolet
-            (5, 2, "quarter", "quarter", 1, Fraction(3, 5)), # 5 quarter notes in the time of 2 dotted quarter notes
+            (3, 2, "eighth", "eighth", 0, 0, Fraction(2, 3)),   # classic 3:2 eighth notes tuplet
+            (5, 4, "eighth", "eighth", 0, 0, Fraction(4, 5)),   # 5:4 eighth notes tuplet
+            (3, 2, "16th", "16th", 0, 0, Fraction(2, 3)),       # 3:2 16th notes tuplet
+            (9, 2, "16th", "quarter", 0, 0, Fraction(8, 9)),    # 9 16th notes against 2 quarter notes
+            (2, 3, "eighth", "eighth", 0, 0, Fraction(3, 2)),   # classic 2:3 duolet
+            (5, 2, "quarter", "quarter", 0, 1, Fraction(3, 5)), # 5 quarter notes in the time of 2 dotted quarter notes
         ]
         # fmt: on
-        for tuplet, (n_actual, n_normal, t_actual, t_normal, d_normal, dur_mult) in zip(
+        for tuplet, (n_act, n_norm, t_act, t_norm, d_act, d_norm, dur_mult) in zip(
             tuplets, real_values
         ):
-            self.assertEqual(tuplet.actual_notes, n_actual)
-            self.assertEqual(tuplet.normal_notes, n_normal)
-            self.assertEqual(tuplet.actual_type, t_actual)
-            self.assertEqual(tuplet.normal_type, t_normal)
-            self.assertEqual(tuplet.normal_dots, d_normal)
+            self.assertEqual(tuplet.actual_notes, n_act)
+            self.assertEqual(tuplet.normal_notes, n_norm)
+            self.assertEqual(tuplet.actual_type, t_act)
+            self.assertEqual(tuplet.normal_type, t_norm)
+            self.assertEqual(tuplet.actual_dots, d_act)
+            self.assertEqual(tuplet.normal_dots, d_norm)
             self.assertEqual(tuplet.duration_multiplier, dur_mult)
 
     def _pretty_export_import_pretty_test(self, part1):

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -228,12 +228,12 @@ class TestMusicXML(unittest.TestCase):
         # (actual_notes, normal_notes, actual_type, normal_type, normal_dots, duration_multiplier)
         # fmt: off
         real_values = [
-            (3, 2, "eighth", "eighth", 0, Fraction(2, 3)),  # classic 3:2 eighth notes tuplet
-            (5, 4, "eighth", "eighth", 0, Fraction(4, 5)),  # 5:4 eighth notes tuplet
-            (3, 2, "16th", "16th", 0, Fraction(2, 3)),      # 3:2 16th notes tuplet
-            (9, 2, "16th", "quarter", 0, Fraction(8, 9)),   # 9 16th notes against 2 quarter notes
-            (2, 3, "eighth", "eighth", 0, Fraction(3, 2)),  # classic 2:3 duolet
-            (5, 2, "quarter", "quarter", 1, Fraction(3, 5)) # 5 quarter notes in the time of 2 dotted quarter notes
+            (3, 2, "eighth", "eighth", 0, Fraction(2, 3)),   # classic 3:2 eighth notes tuplet
+            (5, 4, "eighth", "eighth", 0, Fraction(4, 5)),   # 5:4 eighth notes tuplet
+            (3, 2, "16th", "16th", 0, Fraction(2, 3)),       # 3:2 16th notes tuplet
+            (9, 2, "16th", "quarter", 0, Fraction(8, 9)),    # 9 16th notes against 2 quarter notes
+            (2, 3, "eighth", "eighth", 0, Fraction(3, 2)),   # classic 2:3 duolet
+            (5, 2, "quarter", "quarter", 1, Fraction(3, 5)), # 5 quarter notes in the time of 2 dotted quarter notes
         ]
         # fmt: on
         for tuplet, (n_actual, n_normal, t_actual, t_normal, d_normal, dur_mult) in zip(


### PR DESCRIPTION
Following my previous PR #414, I noticed that it didn't cover all possible tuplets cases. In particular, in addition to allow things like "5 eighth notes in the space of 2 quarter notes", MusicXML also allows things like "5 eighth notes in the space of 2 **dotted** quarter notes". My previous implementation wasn't taking into account the eventual dots in the tuplet normal duration.

Those dots can be seen in two places:
- As `<tuplet-dot/>` in `<tuplet-normal>` or `<tuplet-actual>` tags (themselves in `<tuplet type="start">` tags)
- As `<normal-dot/>` tags in `<time-modification>` tags (not sure why there isn't any `<actual-dot/>` in the MusicXML spec)

I've adapted the tuplet test to test one of those dotted cases too.

References:
- https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/tuplet-normal
- https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/tuplet-actual
- https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/time-modification/