### PR TITLE
Fix articulations/ornaments/technical default value

### DIFF
--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -1293,19 +1293,19 @@ def _handle_note(e, position, part, ongoing, prev_note, doc_order, prev_beam=Non
     if articulations_e is not None:
         articulations = get_articulations(articulations_e)
     else:
-        articulations = {}
+        articulations = []
 
     ornaments_e = e.find("notations/ornaments")
     if ornaments_e is not None:
         ornaments = get_ornaments(ornaments_e)
     else:
-        ornaments = {}
+        ornaments = []
 
     technical_e = e.find("notations/technical")
     if technical_e is not None:
         technical_notations = get_technical_notations(technical_e)
     else:
-        technical_notations = {}
+        technical_notations = []
 
     pitch = e.find("pitch")
     unpitch = e.find("unpitched")


### PR DESCRIPTION
Currently, when parsing a XML score, a note without any articulation, ornament, or technical notation returns an empty dict when accessing those attributes. However, when there are such articulations (or ornaments or technical notations), then accessing the attributes returns a list and no longer a dict.

This is due to the functions `get_articulations`, `get_ornaments` and `get_technical_notations` all returning lists, but when there is no `<notation>`, then the parser sets them to `{}`.

This PR simply set the default value to an empty list rather than an empty dict for consistency.

I don't think this could cause any issues, let me know if it does.