### PR TITLE
Accept int64 values for 'onset_div' in note array

### DIFF
--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -2423,7 +2423,7 @@ def note_array_from_note_list(
     if quarter_map is not None:
         fields += [("onset_quarter", "f4"), ("duration_quarter", "f4")]
     fields += [
-        ("onset_div", "i4"),
+        ("onset_div", "i8"),
         ("duration_div", "i4"),
         ("pitch", "i4"),
         ("voice", "i4"),

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -2424,7 +2424,7 @@ def note_array_from_note_list(
         fields += [("onset_quarter", "f4"), ("duration_quarter", "f4")]
     fields += [
         ("onset_div", "i8"),
-        ("duration_div", "i4"),
+        ("duration_div", "i8"),
         ("pitch", "i4"),
         ("voice", "i4"),
         ("id", "U256"),


### PR DESCRIPTION
Convert the 'onset_div' field in note arrays to accept 64 bit integer values in order to accommodate large scores