### PR TITLE
Fix removing last point

### DIFF
--- a/partitura/score.py
+++ b/partitura/score.py
@@ -950,13 +950,22 @@ class Part(object):
     def _remove_point(self, tp):
         i = np.searchsorted(self._points, tp)
         if self._points[i] == tp:
+            # If not on bound, link prev and next points together
+            if i > 0 and i < len(self._points) - 1:
+                self._points[i - 1].next = self._points[i + 1]
+                self._points[i + 1].prev = self._points[i - 1]
+            # If last point, set previous point as last one
+            elif i > 0:
+                self._points[i - 1].next = None
+            # If first point, set next point as first one
+            elif i < len(self._points) - 1:
+                self._points[i - 1].prev = None
+            # That last case only happen when there is a single point in the array,
+            # no prev/next update in that cas, simply delete
+            else:
+                pass
+            # Actually delete the point
             self._points = np.delete(self._points, i)
-            if i > 0:
-                self._points[i - 1].next = self._points[i]
-                self._points[i].prev = self._points[i - 1]
-            if i < len(self._points) - 1:
-                self._points[i].next = self._points[i + 1]
-                self._points[i + 1].prev = self._points[i]
 
     def get_point(self, t):
         """Return the `TimePoint` object with time `t`, or None if

--- a/tests/test_part_properties.py
+++ b/tests/test_part_properties.py
@@ -33,6 +33,70 @@ class TestingPartProperties(unittest.TestCase):
         self.assertTrue(len(part.dynamics) == 1)
         self.assertTrue(len(part.repeats) == 0)
 
+    def test_removing_points(self):
+        part = score.Part("P0", "My Part")
+        part.set_quarter_duration(0, 10)
+        part.add((ts0 := score.TimeSignature(3, 4)), start=0)
+        part.add((ts1 := score.TimeSignature(4, 4)), start=20)
+        part.add((n0 := score.Note(id="n0", step="A", octave=4)), start=0, end=10)
+        part.add((r0 := score.Rest(id="r0")), start=10, end=20)
+        part.add((n1 := score.Note(id="n1", step="A", octave=4)), start=20, end=30)
+
+        # Part id="P0" name="My Part"
+        #  ├─ TimePoint t=0 quarter=10
+        #  │   └─ starting objects
+        #  │       ├─ 0--10 Note id=n0 voice=None staff=None type=quarter pitch=A4
+        #  │       └─ 0-- TimeSignature 3/4
+        #  ├─ TimePoint t=10 quarter=10
+        #  │   ├─ ending objects
+        #  │   │   └─ 0--10 Note id=n0 voice=None staff=None type=quarter pitch=A4
+        #  │   └─ starting objects
+        #  │       └─ 10--20 Rest id=r0 voice=None staff=None type=quarter
+        #  ├─ TimePoint t=20 quarter=10
+        #  │   ├─ ending objects
+        #  │   │   └─ 10--20 Rest id=r0 voice=None staff=None type=quarter
+        #  │   └─ starting objects
+        #  │       ├─ 20--30 Note id=n1 voice=None staff=None type=quarter pitch=A4
+        #  │       └─ 20-- TimeSignature 4/4
+        #  └─ TimePoint t=30 quarter=10
+        #      └─ ending objects
+        #          └─ 20--30 Note id=n1 voice=None staff=None type=quarter pitch=A4
+
+        # Points: [0, 10, 20, 30]
+        p0, p10, p20, p30 = part._points
+
+        # Removing n0 should not affect the score (start and end point still needed)
+        num_points = len(part._points)
+        part.remove(n0)
+        self.assertTrue(len(part._points) == num_points)
+
+        # Removing r0 should remove the point 10
+        part.remove(r0)
+        self.assertTrue(len(part._points) == num_points - 1)
+        self.assertTrue(p0.next is p20)
+        self.assertTrue(p20.prev is p0)
+
+        # Removing n1 should remove the last point
+        part.remove(n1)
+        self.assertTrue(len(part._points) == num_points - 2)
+        self.assertTrue(part.last_point is p20)
+        self.assertTrue(p20.next is None)
+
+        # Removing the first TS should set p20 to the first point
+        part.remove(ts0)
+        self.assertTrue(part.first_point is p20)
+        self.assertTrue(p20.prev is None)
+
+        # Removing all but one point should result in prev/next being None
+        self.assertTrue(len(part._points) == 1)
+        self.assertTrue(part.first_point is part.last_point)
+        self.assertTrue(part.first_point.prev is None)
+        self.assertTrue(part.first_point.next is None)
+
+        # Removing last point should not error
+        part.remove(ts1)
+        self.assertTrue(len(part._points) == 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The current implementation of `Part._remove_point` would fail with an index error when required to remove the last point of the score.:
```py
    def _remove_point(self, tp):
        i = np.searchsorted(self._points, tp)
        if self._points[i] == tp:
            self._points = np.delete(self._points, i)
            if i > 0:
                self._points[i - 1].next = self._points[i]
                self._points[i].prev = self._points[i - 1]
            if i < len(self._points) - 1:
                self._points[i].next = self._points[i + 1]
                self._points[i + 1].prev = self._points[i]
```
When is the last point of the array, the `if i > 0` branch tries to access `self._points[i]` which has been deleted, resulting in an index error.

The new implementation fixes that, and adds tests for that behaviour.