### PR TITLE
Fix transposition issues

### DIFF
--- a/partitura/assets/score_example.musicxml
+++ b/partitura/assets/score_example.musicxml
@@ -13,6 +13,9 @@
     <measure number="1">
       <attributes>
         <divisions>12</divisions>
+        <key>
+           <fifths>0</fifths>
+        </key>
         <time>
           <beats>4</beats>
           <beat-type>4</beat-type>

--- a/partitura/io/importdcml.py
+++ b/partitura/io/importdcml.py
@@ -284,7 +284,7 @@ def read_harmony_tsv(beat_tsv_path, part):
         # key_alter = re.search(r"[#b]", row["globalkey"]).group(0) if re.search(r"[#b]", row["globalkey"]) else ""
         # key_alter = key_alter.replace("b", "-")
         # key_alter = ALT_TO_INT[key_alter]
-        # key_step, key_alter = transpose_note(key_step, key_alter, transposition_interval)
+        # key_step, key_alter, _ = transpose_note_attributes(transposition_interval, key_step, key_alter)
         # local_key = key_step + INT_TO_ALT[key_alter]
         part.add(
             spt.Cadence(

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -6179,7 +6179,7 @@ def process_local_key(loc_k, glob_k, return_step_alter=False):
     )
     key_alter = key_alter.replace("b", "-")
     key_alter = ALT_TO_INT[key_alter]
-    key_step, key_alter, _ = transpose_note_attributes_attributes(
+    key_step, key_alter, _ = transpose_note_attributes(
         transposition_interval, key_step, key_alter
     )
     if return_step_alter:

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -50,7 +50,7 @@ from partitura.utils import (
     clef_sign_to_int,
 )
 from partitura.utils.generic import interp1d
-from partitura.utils.music import transpose_note, step2pc
+from partitura.utils.music import transpose_note_attributes, step2pc
 from partitura.utils.globals import (
     INT_TO_ALT,
     ALT_TO_INT,
@@ -3158,7 +3158,7 @@ class RomanNumeral(Harmony):
                 if self.local_key.islower()
                 else Roman2Interval_Maj[self.secondary_degree]
             )
-            step, alter = transpose_note(key_step, key_alter, interval)
+            step, alter, _ = transpose_note_attributes(interval, key_step, key_alter)
         except KeyError:
             loc_k = self.secondary_degree
             glob_k = self.local_key
@@ -3171,7 +3171,7 @@ class RomanNumeral(Harmony):
                 if self.secondary_degree.islower()
                 else Roman2Interval_Maj[self.primary_degree]
             )
-            step, alter = transpose_note(step, alter, interval)
+            step, alter, _ = transpose_note_attributes(interval, step, alter)
             root = step + INT_TO_ALT[alter]
         except KeyError:
             loc_k = self.primary_degree
@@ -3189,13 +3189,17 @@ class RomanNumeral(Harmony):
 
         if self.inversion == 1:
             if self.primary_degree.islower():
-                step, alter = transpose_note(step, alter, Interval(3, "m"))
+                step, alter, _ = transpose_note_attributes(
+                    Interval(3, "m"), step, alter
+                )
             else:
-                step, alter = transpose_note(step, alter, Interval(3, "M"))
+                step, alter, _ = transpose_note_attributes(
+                    Interval(3, "M"), step, alter
+                )
         elif self.inversion == 2:
-            step, alter = transpose_note(step, alter, Interval(5, "P"))
+            step, alter, _ = transpose_note_attributes(Interval(5, "P"), step, alter)
         elif self.inversion == 3:
-            step, alter = transpose_note(step, alter, Interval(7, "m"))
+            step, alter, _ = transpose_note_attributes(Interval(7, "m"), step, alter)
 
         bass_note_name = step + INT_TO_ALT[alter]
         return bass_note_name
@@ -6087,7 +6091,9 @@ def process_local_key(loc_k_text, glob_k_text, return_step_alter=False):
     )
     key_alter = key_alter.replace("b", "-")
     key_alter = ALT_TO_INT[key_alter]
-    key_step, key_alter = transpose_note(key_step, key_alter, transposition_interval)
+    key_step, key_alter, _ = transpose_note_attributes(
+        transposition_interval, key_step, key_alter
+    )
     if return_step_alter:
         return key_step, key_alter
     local_key = (
@@ -6173,7 +6179,9 @@ def process_local_key(loc_k, glob_k, return_step_alter=False):
     )
     key_alter = key_alter.replace("b", "-")
     key_alter = ALT_TO_INT[key_alter]
-    key_step, key_alter = transpose_note(key_step, key_alter, transposition_interval)
+    key_step, key_alter, _ = transpose_note_attributes_attributes(
+        transposition_interval, key_step, key_alter
+    )
     if return_step_alter:
         return key_step, key_alter
     local_key = (

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     # For this to work we need to import annotations from __future__
     # Solution from
     # https://medium.com/quick-code/python-type-hinting-eliminating-importerror-due-to-circular-imports-265dfb0580f8
-    from partitura.score import ScoreLike, Interval
+    from partitura.score import ScoreLike, Interval, Note, KeySignature
     from partitura.performance import PerformanceLike, Performance, PerformedPart
 
 
@@ -143,24 +143,24 @@ def ensure_rest_array(restarray_or_part, *args, **kwargs):
         )
 
 
-def _transpose_step(step, interval, direction):
+def _transpose_step(step: str, num_steps: int, direction: str):
     """
     Transpose a note by a given interval.
     Parameters
     ----------
-    step
-    inverval
-
+    step: Step to transpose
+    num_steps: Number of steps (not semitones) to transpose
+    direction: Direction of the transposition
     """
     op = lambda x, y: abs(x + y) % 7 if direction == "up" else abs(x - y) % 7
-    if interval == "P1":
+    if num_steps == 1:
         pass
     else:
-        step = STEPS[op(STEPS[step.capitalize()], interval - 1)]
+        step = STEPS[op(STEPS[step.capitalize()], num_steps - 1)]
     return step
 
 
-def _transpose_note_inplace(note, interval):
+def _transpose_note_inplace(note: Note, interval: Interval, update_ties: bool = True):
     """
     Transpose a note by a given interval.
     Parameters
@@ -172,30 +172,40 @@ def _transpose_note_inplace(note, interval):
     if interval.quality + str(interval.number) == "P1":
         pass
     else:
-        # TODO work for arbitrary octave.
-        prev_step = note.step.capitalize()
-        note.step = _transpose_step(prev_step, interval.number, interval.direction)
-        if STEPS[note.step] - STEPS[prev_step] < 0 and interval.direction == "up":
-            note.octave += 1
-        elif STEPS[note.step] - STEPS[prev_step] > 0 and interval.direction == "down":
-            note.octave -= 1
-        else:
-            note.octave = note.octave
-        prev_alter = note.alter if note.alter is not None else 0
-        prev_pc = MIDI_BASE_CLASS[prev_step.lower()] + prev_alter
-        tmp_pc = MIDI_BASE_CLASS[note.step.lower()]
-        if interval.direction == "up":
-            diff_sm = tmp_pc - prev_pc if tmp_pc >= prev_pc else tmp_pc + 12 - prev_pc
-        else:
-            diff_sm = prev_pc - tmp_pc if prev_pc >= tmp_pc else prev_pc + 12 - tmp_pc
-        note.alter = (
-            INTERVAL_TO_SEMITONES[interval.quality + str(interval.number)] - diff_sm
+        new_step, new_alter, new_octave = transpose_note_attributes(
+            interval=interval,
+            step=note.step,
+            alter=note.alter,
+            octave=note.octave,
         )
+        note.step = new_step
+        note.alter = new_alter
+        note.octave = new_octave
+        if update_ties:
+            for tied_note in note.tie_next_notes:
+                _transpose_note_inplace(tied_note, interval, update_ties=False)
 
 
-def transpose_note_old(step, alter, interval):
+def _transpose_ks_inplace(ks: KeySignature, interval: Interval):
+    key = ks.name
+    step = key[0]
+    alter = key.count("#") - key.count("b")
+    new_step, new_alter, _ = transpose_note_attributes(interval, step=step, alter=alter)
+    new_fifths, mode = key_name_to_fifths_mode(new_step + ALTER_SIGNS[new_alter])
+    ks.fifths = new_fifths
+
+
+def transpose_note_attributes(
+    interval: Interval,
+    step: str,
+    alter: int = 0,
+    octave: int = 0,
+):
     """
-    Transpose a note by a given interval without changing the octave or creating a Note Object.
+    Transpose a note by a given interval.
+    It can transpose a step, a step+alteration, and a step+alteration+octave.
+
+    This function does not create a new Note object, but returns the new attributes.
 
 
     Parameters
@@ -203,7 +213,9 @@ def transpose_note_old(step, alter, interval):
     step: str
         The step of the pitch, e.g. C, D, E, etc.
     alter: int
-        The alteration of the pitch, e.g. -2, -1, 0, 1, 2 etc.
+        The alteration of the pitch, e.g. -2, -1, 0, 1, 2, etc.
+    octave: int
+        The octave of the note, e.g. 1, 2, 3, etc.
     interval: Interval
         The interval to transpose by.
 
@@ -214,50 +226,8 @@ def transpose_note_old(step, alter, interval):
     new_alter: int
         The new alteration of the pitch, e.g. -2, -1, 0, 1, 2 etc.
     """
-    if interval.quality + str(interval.number) == "P1":
-        new_step = step
-        new_alter = alter
-    else:
-        prev_step = step.capitalize()
-        new_step = _transpose_step(prev_step, interval.number, interval.direction)
-        prev_alter = alter if alter is not None else 0
-        prev_pc = MIDI_BASE_CLASS[prev_step.lower()] + prev_alter
-        tmp_pc = MIDI_BASE_CLASS[new_step.lower()]
-        if interval.direction == "up":
-            diff_sm = tmp_pc - prev_pc if tmp_pc >= prev_pc else tmp_pc + 12 - prev_pc
-        else:
-            diff_sm = prev_pc - tmp_pc if prev_pc >= tmp_pc else prev_pc + 12 - tmp_pc
-        new_alter = (
-            INTERVAL_TO_SEMITONES[interval.quality + str(interval.number)] - diff_sm
-        )
-    return new_step, new_alter
-
-
-def transpose_note(step, alter, interval):
-    """
-    Transpose a note by a given interval without considering the octave.
-
-    This function does not create a new Note object, but returns the new step and alteration of the note.
-
-
-    Parameters
-    ----------
-    step: str
-        The step of the pitch, e.g. C, D, E, etc.
-    alter: int
-        The alteration of the pitch, e.g. -2, -1, 0, 1, 2 etc.
-    interval: Interval
-        The interval to transpose by. Only interval direction "up" is supported.
-
-    Returns
-    -------
-    new_step: str
-        The new step of the pitch, e.g. C, D, E, etc.
-    new_alter: int
-        The new alteration of the pitch, e.g. -2, -1, 0, 1, 2 etc.
-    """
     prev_step = step.capitalize()
-    assert interval.direction == "up", "Only interval direction 'up' is supported."
+    alter = alter or 0
     assert -3 < alter < 3, f"Input Alteration {alter} is not in the range -2 to 2."
     assert (
         interval.number < 8
@@ -265,19 +235,37 @@ def transpose_note(step, alter, interval):
     assert (
         prev_step in BASE_PC.keys()
     ), f"Input Step {prev_step} is must be one of: {BASE_PC.keys()}."
-    new_step = STEPS[(STEPS[prev_step] + interval.number - 1) % 7]
+    # Compute new step
+    sign = 1 if interval.direction == "up" else -1
+    new_step = STEPS[(STEPS[prev_step] + sign * (interval.number - 1)) % 7]
+    # Compute new octave
+    diff_step = STEPS[new_step] - STEPS[prev_step]
+    new_octave = octave
+    if diff_step < 0 and interval.direction == "up":
+        new_octave += 1
+    elif diff_step > 0 and interval.direction == "down":
+        new_octave -= 1
+    # Compute new alteration
     prev_alter = alter if alter is not None else 0
     pc_prev = step2pc(prev_step, prev_alter)
     pc_new = step2pc(new_step, prev_alter)
-    new_alter = interval.semitones - (pc_new - pc_prev) % 12 + prev_alter
+    new_alter = (
+        sign * interval.semitones - (pc_new - pc_prev) % (sign * 12) + prev_alter
+    )
+
     # add test to check if the new alteration is correct (i.e. accept maximum of 2 flats or sharps)
     assert (
         -3 < new_alter < 3
     ), f"New alteration {new_alter} is not in the range -2 to 2."
-    return new_step, new_alter
+    return new_step, new_alter, new_octave
 
 
-def transpose(score: ScoreLike, interval: Interval) -> ScoreLike:
+def transpose(
+    score: ScoreLike,
+    interval: Interval,
+    transpose_key_signatures: bool = False,
+    inplace: bool = False,
+) -> ScoreLike:
     """
     Transpose a score by a given interval.
 
@@ -287,6 +275,9 @@ def transpose(score: ScoreLike, interval: Interval) -> ScoreLike:
         Score to be transposed.
     interval : int
         Interval to transpose by.
+    inplace : bool
+        Whether to transpose the score in place or return a new score.
+        Note that you might need to increase the recursion limit if you want a copy.
 
     Returns
     -------
@@ -294,22 +285,30 @@ def transpose(score: ScoreLike, interval: Interval) -> ScoreLike:
         Transposed score.
     """
     import partitura.score as s
-    import sys
 
-    # Copy needs to be deep, otherwise the recursion limit will be exceeded
-    old_recursion_depth = sys.getrecursionlimit()
-    sys.setrecursionlimit(10000)
-    # Deep copy of score
-    new_score = copy.deepcopy(score)
-    # Reset recursion limit to previous value to avoid side effects
-    sys.setrecursionlimit(old_recursion_depth)
+    if not inplace:
+        score = copy.deepcopy(score)
+
+    # If Score, transpose all parts
     if isinstance(score, s.Score):
-        for part in new_score.parts:
-            transpose(part, interval)
+        for part in score.parts:
+            transpose(
+                part,
+                interval,
+                transpose_key_signatures=transpose_key_signatures,
+                inplace=True,
+            )
+
+    # If part, transpose it
     elif isinstance(score, s.Part):
-        for note in score.notes_tied:
-            _transpose_note_inplace(note, interval)
-    return new_score
+        if transpose_key_signatures:
+            for ks in score.iter_all(cls=s.KeySignature):
+                _transpose_ks_inplace(ks, interval)
+        # for note in score.notes_tied:
+        #     _transpose_note_inplace(note, interval, update_ties=True)
+        for note in score.notes:
+            _transpose_note_inplace(note, interval, update_ties=False)
+    return score
 
 
 def get_time_units_from_note_array(note_array):

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -288,6 +288,9 @@ def transpose(
 
     if not inplace:
         score = copy.deepcopy(score)
+        # In case score is a Score object, set inplace to True
+        # so that each part will not be deepcopied again
+        inplace = True
 
     # If Score, transpose all parts
     if isinstance(score, s.Score):
@@ -296,7 +299,7 @@ def transpose(
                 part,
                 interval,
                 transpose_key_signatures=transpose_key_signatures,
-                inplace=True,
+                inplace=inplace,
             )
 
     # If part, transpose it

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -304,10 +304,8 @@ def transpose(
         if transpose_key_signatures:
             for ks in score.iter_all(cls=s.KeySignature):
                 _transpose_ks_inplace(ks, interval)
-        # for note in score.notes_tied:
-        #     _transpose_note_inplace(note, interval, update_ties=True)
-        for note in score.notes:
-            _transpose_note_inplace(note, interval, update_ties=False)
+        for note in score.notes_tied:
+            _transpose_note_inplace(note, interval, update_ties=True)
     return score
 
 

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -192,6 +192,12 @@ def _transpose_ks_inplace(ks: KeySignature, interval: Interval):
     alter = key.count("#") - key.count("b")
     new_step, new_alter, _ = transpose_note_attributes(interval, step=step, alter=alter)
     new_fifths, mode = key_name_to_fifths_mode(new_step + ALTER_SIGNS[new_alter])
+    if abs(new_fifths) > 7:
+        raise ValueError(
+            f"Key signature {ks.name} transposed by {interval} results in an invalid "
+            f"key signature with {new_fifths} fifths. The maximum number of fifths is "
+            f"+/- 7.",
+        )
     ks.fifths = new_fifths
 
 

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -164,11 +164,12 @@ def _transpose_step(step: str, num_steps: int, direction: str):
 def _transpose_note_inplace(note: Note, interval: Interval, update_ties: bool = True):
     """
     Transpose a note by a given interval.
+
     Parameters
     ----------
-    note
-    inverval
-
+    note: Note to transpose
+    interval: Interval to transpose by
+    update_ties: Whether to update tied notes
     """
     if interval.quality + str(interval.number) == "P1":
         pass
@@ -249,21 +250,23 @@ def transpose_note_attributes(
 
     Parameters
     ----------
-    step: str
-        The step of the pitch, e.g. C, D, E, etc.
-    alter: int
-        The alteration of the pitch, e.g. -2, -1, 0, 1, 2, etc.
-    octave: int
-        The octave of the note, e.g. 1, 2, 3, etc.
     interval: Interval
         The interval to transpose by.
+    step: str
+        The step of the note, e.g. C, D, E, etc.
+    alter: int
+        The alteration of the note, e.g. -2, -1, 0, 1, 2, etc.
+    octave: int
+        The octave of the note, e.g. 1, 2, 3, etc.
 
     Returns
     -------
     new_step: str
-        The new step of the pitch, e.g. C, D, E, etc.
+        The new step of the note, e.g. C, D, E, etc.
     new_alter: int
-        The new alteration of the pitch, e.g. -2, -1, 0, 1, 2 etc.
+        The new alteration of the note, e.g. -2, -1, 0, 1, 2 etc.
+    new_octave: int
+        The new octave of the note, e.g. 1, 2, 3, etc.
     """
     prev_step = step.capitalize()
     alter = alter or 0
@@ -314,6 +317,8 @@ def transpose(
         Score to be transposed.
     interval : int
         Interval to transpose by.
+    transpose_key_signatures : bool
+        Whether to transpose key signatures.
     inplace : bool
         Whether to transpose the score in place or return a new score.
         Note that you might need to increase the recursion limit if you want a copy.

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -144,23 +144,6 @@ def ensure_rest_array(restarray_or_part, *args, **kwargs):
         )
 
 
-def _transpose_step(step: str, num_steps: int, direction: str):
-    """
-    Transpose a note by a given interval.
-    Parameters
-    ----------
-    step: Step to transpose
-    num_steps: Number of steps (not semitones) to transpose
-    direction: Direction of the transposition
-    """
-    op = lambda x, y: abs(x + y) % 7 if direction == "up" else abs(x - y) % 7
-    if num_steps == 1:
-        pass
-    else:
-        step = STEPS[op(STEPS[step.capitalize()], num_steps - 1)]
-    return step
-
-
 def _transpose_note_inplace(note: Note, interval: Interval, update_ties: bool = True):
     """
     Transpose a note by a given interval.

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -12,6 +12,7 @@ import numpy as np
 from scipy.interpolate import interp1d
 from scipy.sparse import csc_matrix
 from typing import Union, Callable, Optional, TYPE_CHECKING, Tuple, Dict, Any, List
+from typing_extensions import deprecated
 from partitura.utils.generic import find_nearest, search, iter_current_next
 from partitura.utils.globals import *
 import partitura
@@ -199,6 +200,38 @@ def _transpose_ks_inplace(ks: KeySignature, interval: Interval):
             f"+/- 7.",
         )
     ks.fifths = new_fifths
+
+
+@deprecated("Starting with version 1.8.0, see transpose_note_attributes instead")
+def transpose_note(step, alter, interval):
+    """
+    DEPRECATED: see function transpose_note_attributes instead.
+    Transpose a note by a given interval without considering the octave.
+    This function does not create a new Note object, but returns the new step and alteration of the note.
+
+    Parameters
+    ----------
+    step: str
+        The step of the pitch, e.g. C, D, E, etc.
+    alter: int
+        The alteration of the pitch, e.g. -2, -1, 0, 1, 2 etc.
+    interval: Interval
+        The interval to transpose by. Only interval direction "up" is supported.
+
+    Returns
+    -------
+    new_step: str
+        The new step of the pitch, e.g. C, D, E, etc.
+    new_alter: int
+        The new alteration of the pitch, e.g. -2, -1, 0, 1, 2 etc.
+    """
+    step, alter, _ = transpose_note_attributes(
+        step=step,
+        alter=alter,
+        interval=interval,
+        octave=0,
+    )
+    return step, alter
 
 
 def transpose_note_attributes(

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -7,7 +7,7 @@ import unittest
 
 from partitura import EXAMPLE_MUSICXML
 from partitura import load_score
-from partitura.score import Interval
+from partitura.score import Interval, KeySignature
 from partitura.utils.music import transpose
 import numpy as np
 
@@ -15,8 +15,11 @@ import numpy as np
 class TransposeScoreByInterval(unittest.TestCase):
     def test_transpose(self):
         score = load_score(EXAMPLE_MUSICXML)
-        interval = Interval(number=5, quality="d")
-        new_score = transpose(score, interval)
+
+        # Test transposing up a diminished fifth
+        # A4 C5 E5 -> Eb5 Gb5 Bb5 (from C to Gb key)
+        interval = Interval(number=5, quality="d", direction="up")
+        new_score = transpose(score, interval, transpose_key_signatures=True)
         note_array = new_score.note_array(include_pitch_spelling=True)
         steps = np.array(["E", "G", "B"])
         alters = np.array([-1, -1, -1])
@@ -24,3 +27,17 @@ class TransposeScoreByInterval(unittest.TestCase):
         self.assertEqual(np.all(steps == note_array["step"]), True)
         self.assertEqual(np.all(alters == note_array["alter"]), True)
         self.assertEqual(np.all(octaves == note_array["octave"]), True)
+        self.assertEqual(next(new_score[0].iter_all(KeySignature)).name, "Gb")
+
+        # Test transposing down a diminished fifth
+        # A4 C5 E5 -> D#4 F#4 A#4 (from C to F# key)
+        interval = Interval(number=5, quality="d", direction="down")
+        new_score = transpose(score, interval, transpose_key_signatures=True)
+        note_array = new_score.note_array(include_pitch_spelling=True)
+        steps = np.array(["D", "F", "A"])
+        alters = np.array([1, 1, 1])
+        octaves = np.array([4, 4, 4])
+        self.assertEqual(np.all(steps == note_array["step"]), True)
+        self.assertEqual(np.all(alters == note_array["alter"]), True)
+        self.assertEqual(np.all(octaves == note_array["octave"]), True)
+        self.assertEqual(next(new_score[0].iter_all(KeySignature)).name, "F#")


### PR DESCRIPTION
*Note: this was first pushed to develop by mistake, I reverted the commit.*

In #443, I raised a couple of concerns regarding the transposition implementation.

In this PR, I'm trying to adress them.

## Breaking ties

Transposing does not break ties anymore. Previously, the only notes that were transposed were `part.notes_tied`, so any subsequent tied notes would be left unmodified.

In my implementation, I added a boolean parameter `update_ties` to `_transpose_note_inplace`, and kept the loop over `part.notes_tied`. Alternatively, I could simply loop over `part.notes` and drop this `update_ties` parameter. What do you think?

## Update key signature

The former implementation was only transposing notes, without affecting the key signature. I've added a parameter `transpose_key_signatures` to `.transpose`, left to `False` by default to keep the old behaviour, that will also transpose the key signatures into the new key. Do you prefer it `True` by default?

I've added a test for this behaviour.

## Handle large scores

Previously, the transpose function was systematically creating a deep copy of the score (and sometimes multiple), which can be very ineffective. Additionally, the recursion limit was manually increased with a hardcoded value, which was preventing to pass scores that would need larger limits.

To address that, I added an `inplace` parameter, that will speed things up if the user wants to directly modify its score. I also removed the recursion limit, and added a sentence in the doc explaining that the user might want to explicitly raise that limit when dealing with large scores and `inplace=False`.

This parameter also allows to fix some bugs in deep copies management that were present before (see original issue for more insights).

## Fix transposing down

In my tests, I discovered that while transposing up was working ok, transposing down was broken, and lead to some quadruple-flats or even septuple-sharps!

I fixed the implementation so that we can now pass ascending or descending intervals without issue. I adapted the tests to test descending interval.

## General refactoring and breaking change

When dealing with this PR, I came across some parts that were very similar in the function `transpose_note` and `_transpose_note_inplace`. The former was dealing with `step` (str) and `alter` (int) (no octave), and the second one were dealing with a `Note` object (including step, alteration and octave). In order to limit duplication, I moved all the transposition logic into a `transpose_note_attributes` function, that deals with step, alteration and octave altogether.

As the name suggest, this function does not operate on a `Note` object, but on individual attributes (like the former `transpose_note`). It takes an `Interval` object, a step (str), an alteration(int) and an octave (int). It has default values for alteration (0) and octave (0), so that one can choose not to use them if not needed.

The issue with that is, as I want default values for `alter` and `octave`, I can't have the `interval` parameter last as before. I could have it in second like `transpose_note_attributes(step, interval, alter=0, octave=0)`, but it feels weird to separate `step` for the other attributes. Finally, I decided to go with `transpose_note_attributes(interval, step, alter=0, octave=0)`, but it's not consistent with the order of `pt.music.transpose(score, interval)`. I don't know if you have any preference about this.

In consequence, I removed the `transpose_note` function, that I was finding quite confusing as it was not dealing with `Note` objects, and couldn't deal with octaves. This is a breaking change, maybe I should deprecate it and call `transpose_note_attributes` under the hood? Let me know if you would rather keep it around.

I replaced all `transpose_note` references in the library with the new `transpose_note_attributes`.