### PR TITLE
Speedup `iter_all`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+
+### Other Changes
+- speedup Part.iter_all
+
 Version 1.6.0 (Released on 2025-02-27)
 --------------------------------------
 


### PR DESCRIPTION
Using `Part.iter_all()` without specifying `cls` sets the class to `object`, and sets `iter_subclasses = True`. This has the unintended consequence that the full python class hierarchy is traversed at each time step. Setting `cls = TimedObject` is equivalent (since any starting/ending objects should be subclasses of TimedObject), and greatly reduces the number of classes to be iterated over.

In my minimal tests, this change gives approx. a 100x speedup.

Fixes https://github.com/CPJKU/partitura/issues/446

p.s. There may be more opportunity for optimization. I will look at this later.