### PR TITLE
fix a bug in the match export

### DIFF
--- a/partitura/musicanalysis/performance_codec.py
+++ b/partitura/musicanalysis/performance_codec.py
@@ -923,7 +923,7 @@ def get_unique_onset_idxs(
 
 
 def notewise_to_onsetwise(notewise_inputs, unique_onset_idxs):
-    """Agregate basis functions per onset"""
+    """Aggregate basis functions per onset"""
 
     if notewise_inputs.ndim == 1:
         shape = len(unique_onset_idxs)

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -4598,11 +4598,11 @@ def add_segments(part, force_new=False):
     boundary_times.sort()
 
     # for every segment get an id, its jump destinations and properties
-    init_character = 65
+    character_map = { i: chr(65+i) for i in range(26)} | { i+26: chr(97+i) for i in range(26)}
     segment_info = dict()
     for i, (s, e) in enumerate(zip(boundary_times[:-1], boundary_times[1:])):
         segment_info[s] = {
-            "ID": chr(init_character + i),
+            "ID": character_map[i],
             "start": s,
             "end": e,
             "to": [],


### PR DESCRIPTION
fixes a bug in the match export where offsets are computed in quarters or with mixed buggy units which leads to wrong outputs for non-4/4 matchfiles. also cleans the match import with clearer names for the various mapping functions used and improves the segment naming scheme.