### PR TITLE
Allow cls parameter of iter_all to take an iterable of classes rather than a single class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Release Notes
 
 
 ### Other Changes
+- Allow `cls` parameter of `iter_all` to take an iterable of classes rather
+  than a single class.
 - Speed up `Part.iter_all()` when called without `cls`.  Although the order in
   which simultaneously starting/ending objects are returned is an implementation
   detail, note that this update may change that order with respect to previous

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -1089,9 +1089,11 @@ class Part(object):
 
         Parameters
         ----------
-        cls : class, optional
+        cls : class or list/tuple of classes, optional
             The class of objects to iterate over. If omitted, iterate
-            over all objects in the part.
+            over all objects in the part. When cls is list/tuple of
+            classes, instances of any class in the list/tuple will be
+            yielded.
         start : :class:`TimePoint`, optional
             The start of the interval to search. If omitted or None,
             the search starts at the start of the timeline. Defaults
@@ -1133,6 +1135,8 @@ class Part(object):
         if cls is None:
             cls = object
             include_subclasses = True
+        elif isinstance(cls, list):
+            cls = tuple(cls)
 
         if mode == "ending":
             for tp in self._points[start_idx:end_idx]:
@@ -1460,12 +1464,13 @@ class TimePoint(ComparableMixin):
 
     def iter_starting(self, cls, include_subclasses=False):
         """Iterate over all objects of type `cls` that start at this
-        time point.
+        time point. When `cls` is a list/tuple of classes, include objects
+        of any class in `cls`.
 
         Parameters
         ----------
-        cls : class
-            The type of objects to iterate over
+        cls : class or list/tuple of classes
+            Class(es) of objects to iterate over
         include_subclasses : bool, optional
             When True, include all objects of all subclasses of `cls`
             in the iteration. Defaults to False.
@@ -1476,21 +1481,29 @@ class TimePoint(ComparableMixin):
             Instance of type `cls`
 
         """
+        if isinstance(cls, list):
+            cls = tuple(cls)
+
         if include_subclasses:
             for key, items in self.starting_objects.items():
                 if issubclass(key, cls):
                     yield from items
         elif cls in self.starting_objects:
             yield from self.starting_objects[cls]
+        elif isinstance(cls, tuple):
+            for c in cls:
+                if c in self.starting_objects:
+                    yield from self.starting_objects[c]
 
     def iter_ending(self, cls, include_subclasses=False):
         """Iterate over all objects of type `cls` that end at this
-        time point.
+        time point. When `cls` is a list/tuple of classes, include objects
+        of any class in `cls`.
 
         Parameters
         ----------
-        cls : class
-            The type of objects to iterate over
+        cls : class or list/tuple of classes
+            Class(es) of objects to iterate over
         include_subclasses : bool, optional
             When True, include all objects of all subclasses of `cls`
             in the iteration. Defaults to False.
@@ -1501,21 +1514,28 @@ class TimePoint(ComparableMixin):
             Instance of type `cls`
 
         """
+        if isinstance(cls, list):
+            cls = tuple(cls)
         if include_subclasses:
             for key, items in self.ending_objects.items():
                 if issubclass(key, cls):
                     yield from items
         elif cls in self.ending_objects:
             yield from self.ending_objects[cls]
+        elif isinstance(cls, tuple):
+            for c in cls:
+                if c in self.ending_objects:
+                    yield from self.ending_objects[c]
 
     def iter_prev(self, cls, eq=False, include_subclasses=False):
         """Iterate backwards in time from the current timepoint over
-        starting object(s) of type `cls`.
+        starting object(s) of type `cls`. When `cls` is a list/tuple of
+        classes, include objects of any class in `cls`.
 
         Parameters
         ----------
-        cls : class
-            Class of objects to iterate over
+        cls : class or list/tuple of classes
+            Class(es) of objects to iterate over
         eq : bool, optional
             If True start iterating at the current timepoint, rather
             than its predecessor. Defaults to False.
@@ -1540,12 +1560,13 @@ class TimePoint(ComparableMixin):
 
     def iter_next(self, cls, eq=False, include_subclasses=False):
         """Iterate forwards in time from the current timepoint over
-        starting object(s) of type `cls`.
+        starting object(s) of type `cls`. When `cls` is a list/tuple
+        of classes, include objects of any class in `cls`.
 
         Parameters
         ----------
-        cls : class
-            Class of objects to iterate over
+        cls : class or list/tuple of classes
+            Class(es) of objects to iterate over
         eq : bool, optional
             If True start iterating at the current timepoint, rather
             than its successor. Defaults to False.

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -51,7 +51,7 @@ from partitura.utils import (
     update_note_ids_after_unfolding,
     clef_sign_to_int,
 )
-from partitura.utils.generic import interp1d, _prepare_iter_cls
+from partitura.utils.generic import interp1d, prepare_iter_cls
 from partitura.utils.music import transpose_note_attributes
 from partitura.utils.globals import (
     INT_TO_ALT,
@@ -1141,7 +1141,7 @@ class Part(object):
             end_idx = np.searchsorted(self._points, end)
 
         # handle default value, warn on potential issues
-        cls, include_subclasses = _prepare_iter_cls(cls, include_subclasses)
+        cls, include_subclasses = prepare_iter_cls(cls, include_subclasses)
 
         for tp in self._points[start_idx:end_idx]:
             yield from tp._iter_objects(
@@ -1522,6 +1522,15 @@ class TimePoint(ComparableMixin):
         mode: Literal["starting", "ending"] = "starting",
         prepare_cls: bool = True,
     ) -> Generator[TimedObject, None, None]:
+        """
+        Generic code to iterate over starting/ending objects.  The `prepare_cls`
+        flag can be used to indicate that there is no need to prepare the `cls`
+        argument.  This is for efficiency, since `_iter_objects` is typically
+        called for many timepoints with the same `cls` (e.g. from
+        `Part.iter_all`), so it makes sense to prepare `cls` only once in
+        advance, and then pass `prepare_cls=False`.
+        """
+
         if mode == "starting":
             items = self.starting_objects
         elif mode == "ending":
@@ -1530,7 +1539,7 @@ class TimePoint(ComparableMixin):
             raise ValueError(f"Invalid mode {mode} (must be 'starting' or 'ending')")
         if prepare_cls:
             # handle default value, warn on potential issues
-            cls, include_subclasses = _prepare_iter_cls(cls, include_subclasses)
+            cls, include_subclasses = prepare_iter_cls(cls, include_subclasses)
 
         if isinstance(cls, type):
             # single target class
@@ -1636,7 +1645,7 @@ class TimePoint(ComparableMixin):
 
         if prepare_cls:
             # handle default value, warn on potential issues
-            cls, include_subclasses = _prepare_iter_cls(cls, include_subclasses)
+            cls, include_subclasses = prepare_iter_cls(cls, include_subclasses)
 
         while tp:
             yield from tp._iter_objects(

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -8,6 +8,8 @@ loudness directions. A score is defined at the highest level by a
 object). This object serves as a timeline at which musical elements
 are registered in terms of their start and end times.
 """
+
+from __future__ import annotations
 from copy import copy, deepcopy
 from collections import defaultdict
 from collections.abc import Iterable
@@ -24,7 +26,7 @@ import sys
 import numpy as np
 import re
 from scipy.interpolate import PPoly
-from typing import Union, List, Optional, Iterator, Any, Iterable as Itertype
+from typing import Union, List, Optional, Iterator, Any, Iterable as Itertype, Type
 import difflib
 from partitura.utils import (
     ComparableMixin,
@@ -1081,8 +1083,13 @@ class Part(object):
             self._remove_point(tp)
 
     def iter_all(
-        self, cls=None, start=None, end=None, include_subclasses=False, mode="starting"
-    ):
+        self,
+        cls: Type[TimedObject] | Iterable[Type[TimedObject]] | None = None,
+        start: TimePoint | None = None,
+        end: TimePoint | None = None,
+        include_subclasses: bool = False,
+        mode: Literal["starting", "ending"] = "starting",
+    ) -> Generator[TimedObject, None, None]:
         """Iterate (in direction of increasing time) over all
         instances of `cls` that either start or end (depending on
         `mode`) in the interval `start` to `end`.  When `start` and
@@ -1458,7 +1465,11 @@ class TimePoint(ComparableMixin):
         obj.end = self
         self.ending_objects[type(obj)].add(obj)
 
-    def iter_starting(self, cls, include_subclasses=False):
+    def iter_starting(
+        self,
+        cls: Type[TimedObject] | Iterable[Type[TimedObject]] | None = None,
+        include_subclasses: bool = False,
+    ) -> Generator[TimedObject, None, None]:
         """Iterate over all objects of type `cls` that start at this
         time point. When `cls` is a list/tuple of classes, include objects
         of any class in `cls`.
@@ -1479,7 +1490,11 @@ class TimePoint(ComparableMixin):
         """
         return self._iter_objects(cls, include_subclasses, mode="starting")
 
-    def iter_ending(self, cls, include_subclasses=False):
+    def iter_ending(
+        self,
+        cls: Type[TimedObject] | Iterable[Type[TimedObject]] | None = None,
+        include_subclasses: bool = False,
+    ) -> Generator[TimedObject, None, None]:
         """Iterate over all objects of type `cls` that end at this
         time point. When `cls` is a list/tuple of classes, include objects
         of any class in `cls`.
@@ -1501,8 +1516,12 @@ class TimePoint(ComparableMixin):
         return self._iter_objects(cls, include_subclasses, mode="ending")
 
     def _iter_objects(
-        self, cls, include_subclasses=False, mode="starting", prepare_cls=True
-    ):
+        self,
+        cls: Type[TimedObject] | Iterable[Type[TimedObject]],
+        include_subclasses: bool = False,
+        mode: Literal["starting", "ending"] = "starting",
+        prepare_cls: bool = True,
+    ) -> Generator[TimedObject, None, None]:
         if mode == "starting":
             items = self.starting_objects
         elif mode == "ending":
@@ -1539,7 +1558,12 @@ class TimePoint(ComparableMixin):
                                 yield obj
                                 yielded.add(obj)
 
-    def iter_prev(self, cls, eq=False, include_subclasses=False):
+    def iter_prev(
+        self,
+        cls: Type[TimedObject] | Iterable[Type[TimedObject]] | None = None,
+        eq: bool = False,
+        include_subclasses: bool = False,
+    ) -> Generator[TimedObject, None, None]:
         """Iterate backwards in time from the current timepoint over
         starting object(s) of type `cls`. When `cls` is a list/tuple of
         classes, include objects of any class in `cls`.
@@ -1563,7 +1587,12 @@ class TimePoint(ComparableMixin):
         """
         return self._iter_next_prev(cls, eq, include_subclasses, mode="prev")
 
-    def iter_next(self, cls, eq=False, include_subclasses=False):
+    def iter_next(
+        self,
+        cls: Type[TimedObject] | Iterable[Type[TimedObject]] | None = None,
+        eq: bool = False,
+        include_subclasses: bool = False,
+    ) -> Generator[TimedObject, None, None]:
         """Iterate forwards in time from the current timepoint over
         starting object(s) of type `cls`. When `cls` is a list/tuple
         of classes, include objects of any class in `cls`.
@@ -1588,8 +1617,13 @@ class TimePoint(ComparableMixin):
         return self._iter_next_prev(cls, eq, include_subclasses, mode="next")
 
     def _iter_next_prev(
-        self, cls, eq=False, include_subclasses=False, mode="next", prepare_cls=True
-    ):
+        self,
+        cls: Type[TimedObject] | Iterable[Type[TimedObject]],
+        eq: bool = False,
+        include_subclasses: bool = False,
+        mode: Literal["next", "prev"] = "next",
+        prepare_cls: bool = True,
+    ) -> Generator[TimedObject, None, None]:
         if not mode in ("next", "prev"):
             raise ValueError(f'Invalid mode {mode} (must be one of "next", "prev")')
 

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -1491,9 +1491,13 @@ class TimePoint(ComparableMixin):
         elif cls in self.starting_objects:
             yield from self.starting_objects[cls]
         elif isinstance(cls, tuple):
+            yielded = set()
             for c in cls:
                 if c in self.starting_objects:
-                    yield from self.starting_objects[c]
+                    for obj in self.starting_objects[c]:
+                        if obj not in yielded:
+                            yield obj
+                            yielded.add(obj)
 
     def iter_ending(self, cls, include_subclasses=False):
         """Iterate over all objects of type `cls` that end at this
@@ -1523,9 +1527,13 @@ class TimePoint(ComparableMixin):
         elif cls in self.ending_objects:
             yield from self.ending_objects[cls]
         elif isinstance(cls, tuple):
+            yielded = set()
             for c in cls:
                 if c in self.ending_objects:
-                    yield from self.ending_objects[c]
+                    for obj in self.ending_objects[c]:
+                        if obj not in yielded:
+                            yield obj
+                            yielded.add(obj)
 
     def iter_prev(self, cls, eq=False, include_subclasses=False):
         """Iterate backwards in time from the current timepoint over

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -663,7 +663,7 @@ def warn_on_subclass(cls, include_subclasses):
                     )
 
 
-def _prepare_iter_cls(cls, include_subclasses):
+def prepare_iter_cls(cls, include_subclasses):
     """Prepare `cls` and `include_subclasses` arguments for iterating time
     points (`Part.iter_all()`, `TimePoint.iter_starting()`, `TimePoint.iter_ending()`,
     `TimePoint.iter_next()`, `TimePoint.iter_prev()`).  This includes setting
@@ -675,7 +675,7 @@ def _prepare_iter_cls(cls, include_subclasses):
         cls = object  # better: TimedObject
         include_subclasses = True
     elif not isinstance(cls, type):
-        # converti iterable to tuple (for usage in issubclass(..., cls))
+        # convert iterable to tuple (for usage in issubclass(..., cls))
         cls = tuple(cls)
 
     if isinstance(cls, tuple):

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -672,14 +672,16 @@ def _prepare_iter_cls(cls, include_subclasses):
     """
     if cls is None:
         # set default values
-        cls = object
+        cls = object  # better: TimedObject
         include_subclasses = True
-    elif isinstance(cls, list):
-        # convert list to tuple (for usage in issubclass(..., cls))
+    elif not isinstance(cls, type):
+        # converti iterable to tuple (for usage in issubclass(..., cls))
         cls = tuple(cls)
+
     if isinstance(cls, tuple):
         # for tuple, warn if classes are repeated or subclasses of each other
         warn_on_subclass(cls, include_subclasses)
+
     return cls, include_subclasses
 
 

--- a/partitura/utils/generic.py
+++ b/partitura/utils/generic.py
@@ -636,6 +636,53 @@ def monotonize_times(
     return s_mono, x_mono
 
 
+def warn_on_subclass(cls, include_subclasses):
+    """
+    Warn if any of the classes in `cls` is a subclass of any other class in
+    `cls`
+    """
+    if include_subclasses:
+        for i, cls1 in enumerate(cls):
+            for j, cls2 in enumerate(cls):
+                if i != j and issubclass(cls1, cls2):
+                    warnings.warn(
+                        (
+                            f"{cls1} is a subclass of {cls2}, any objects "
+                            "matching multiple classes will only be returned once"
+                        )
+                    )
+    else:
+        for i, cls1 in enumerate(cls):
+            for j, cls2 in enumerate(cls[:i]):
+                if cls1 == cls2:
+                    warnings.warn(
+                        (
+                            f"{cls1} occurs multiple times in list {cls}, any objects "
+                            "matching multiple classes will only be returned once"
+                        )
+                    )
+
+
+def _prepare_iter_cls(cls, include_subclasses):
+    """Prepare `cls` and `include_subclasses` arguments for iterating time
+    points (`Part.iter_all()`, `TimePoint.iter_starting()`, `TimePoint.iter_ending()`,
+    `TimePoint.iter_next()`, `TimePoint.iter_prev()`).  This includes setting
+    appropriate default values, and and issuing a warning if a list/tuple
+    repeated classes or classes that are subclasses of each other.
+    """
+    if cls is None:
+        # set default values
+        cls = object
+        include_subclasses = True
+    elif isinstance(cls, list):
+        # convert list to tuple (for usage in issubclass(..., cls))
+        cls = tuple(cls)
+    if isinstance(cls, tuple):
+        # for tuple, warn if classes are repeated or subclasses of each other
+        warn_on_subclass(cls, include_subclasses)
+    return cls, include_subclasses
+
+
 if __name__ == "__main__":
     import doctest
 

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -1,0 +1,104 @@
+"""
+This module tests that iter_all can be called with both an individual class and
+a list/tuple of classes.
+"""
+
+import unittest
+from tests import MUSICXML_SCORE_OBJECT_TESTFILES
+import partitura as prt
+
+
+class TestingIterMethods(unittest.TestCase):
+    """
+    A test class for testing the iter_all method in the Partitura library.
+
+    This test suite checks various behaviors of the iter_all method, including
+    its ability to iterate over different classes and handle various method
+    parameters.
+    """
+
+    def setUp(self):
+        """
+        Prepare test data by loading MusicXML files for testing.
+
+        Loads each MusicXML file from MUSICXML_SCORE_OBJECT_TESTFILES into
+        the self.scores list, ensuring note IDs are preserved.
+
+        Raises:
+            AssertionError: If no test files are found in MUSICXML_SCORE_OBJECT_TESTFILES.
+        """
+        self.scores = []
+        assert len(MUSICXML_SCORE_OBJECT_TESTFILES) > 0, (
+            "no MUSICXML_SCORE_OBJECT_TESTFILES found"
+        )
+        for fn in MUSICXML_SCORE_OBJECT_TESTFILES:
+            score = prt.load_musicxml(fn, force_note_ids="keep")
+            assert len(score.parts) > 0, (
+                f"No parts found in {MUSICXML_SCORE_OBJECT_TESTFILES[i]}"
+            )
+            self.scores.append(score)
+
+    def _test_iter_methods(self, kwargs):
+        """
+        Test the iter_all method with various class iteration scenarios.
+
+        This method tests iter_all with different input configurations:
+        1. Single class iteration
+        2. Multiple class iteration (as tuple)
+        3. Multiple class iteration (as list)
+
+        Args:
+            kwargs (dict): Optional keyword arguments to pass to iter_all method.
+                           Can include 'include_subclasses' and 'mode'.
+
+        Raises:
+            AssertionError: If the sum of iterated items for individual classes
+            not does not match the number of iterated items for the tuple/list of
+            classes.
+        """
+        for i, score in enumerate(self.scores):
+            part = score.parts[0]
+
+            # Define two different classes to test iteration
+            cls1 = prt.score.Note
+            cls2 = prt.score.TimeSignature
+
+            # Iterate through all notes in the part
+            items1 = tuple(part.iter_all(cls1, **kwargs))
+            # Iterate through all time signatures in the part
+            items2 = tuple(part.iter_all(cls2, **kwargs))
+            # Count the number of items for each class
+            n1 = len(items1)
+            n2 = len(items2)
+
+            # Create a tuple of classes to iterate through
+            cls3 = tuple((cls1, cls2))
+            # Iterate through both notes and time signatures simultaneously
+            items3 = tuple(part.iter_all(cls3, **kwargs))
+            # Check that the total number of items matches the sum of individual class items
+            n3 = len(items3)
+            assert n3 == n1 + n2
+
+            # Repeat the same test using a list of classes instead of a tuple
+            cls4 = list((cls1, cls2))
+            items4 = tuple(part.iter_all(cls4, **kwargs))
+            n4 = len(items4)
+            # Verify that the number of items is consistent
+            assert n4 == n1 + n2
+
+    def test_iter_methods(self):
+        """
+        Test the iter_all method with various parameter combinations.
+
+        This method tests iter_all with:
+        1. Default parameters
+        2. Combinations of include_subclasses (True/False) and modes: "starting"
+           and "ending"
+        """
+        kwargs = {}
+        self._test_iter_methods(kwargs)
+
+        for incl_subcl in (True, False):
+            for mode in ("starting", "ending"):
+                kwargs = {"include_subclasses": incl_subcl, "mode": mode}
+                self._test_iter_methods(kwargs)

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -86,6 +86,25 @@ class TestingIterMethods(unittest.TestCase):
             # Verify that the number of items is consistent
             assert n4 == n1 + n2
 
+    def test_iter_warning(self):
+        """ """
+        for i, score in enumerate(self.scores):
+            part = score.parts[0]
+
+            include_subclasses = True
+            cls1 = [prt.score.Note, prt.score.GenericNote]
+
+            # assert we get a warning because Note is a GenericNote subclass
+            with self.assertWarns(UserWarning):
+                items1 = tuple(
+                    part.iter_all(cls1, include_subclasses=include_subclasses)
+                )
+
+            cls2 = prt.score.GenericNote
+            items2 = tuple(part.iter_all(cls2, include_subclasses=include_subclasses))
+
+            assert len(items1) == len(items2)
+
     def test_iter_methods(self):
         """
         Test the iter_all method with various parameter combinations.


### PR DESCRIPTION
Fixes https://github.com/CPJKU/partitura/issues/426
Supersedes https://github.com/CPJKU/partitura/pull/428

- [x] Refactor iter. next/prev starting/ending methods to reduce duplication
- [x] Allow `cls` to be any iterable of classes
- [x] Ensure objects returned by iter_starting/iter_ending follow the order specified in `cls`
- [x] Add type annotations