### PR TITLE
match file midi track handling

### DIFF
--- a/partitura/io/importmatch.py
+++ b/partitura/io/importmatch.py
@@ -347,12 +347,15 @@ def performed_part_from_match(
     note_onsets_in_secs = np.array(np.zeros(len(mf.notes)), dtype=float)
     note_onsets_in_tick = np.array(np.zeros(len(mf.notes)), dtype=int)
     tracks = set()
+    channels = set()
     for i, note in enumerate(mf.notes):
         n_onset_sec = midi_ticks_to_seconds(note.Onset, mpq, ppq)
         note_onsets_in_secs[i] = n_onset_sec
         note_onsets_in_tick[i] = note.Onset
         track = getattr(note, "Track", 0)
         tracks.add(track)
+        channel=getattr(note, "Channel", 0)
+        channels.add(channel)
         notes.append(
             dict(
                 id=format_pnote_id(note.Id),
@@ -364,7 +367,7 @@ def performed_part_from_match(
                 sound_off=midi_ticks_to_seconds(note.Offset, mpq, ppq),
                 velocity=note.Velocity,
                 track=track,
-                channel=getattr(note, "Channel", 0),
+                channel=channel,
             )
         )
     # Set first note_on to zero in ticks and seconds if first_note_at_zero
@@ -379,12 +382,28 @@ def performed_part_from_match(
                 note["note_on_tick"] -= offset_tick
                 note["note_off_tick"] -= offset_tick
 
+    # check if multiple tracks are in the match file
+    if len(tracks) > 1:
+        warnings.warn(
+                "Notes on multiple MIDI tracks in matchfile" "information!."
+            )
+    used_track = min(tracks)
+    # check if multiple tracks are in the match file
+    if len(channels) > 1:
+        warnings.warn(
+                "Notes on multiple MIDI channels in matchfile" "information!."
+            )
+    used_channel = min(channels)
+
+
     # SustainPedal instances for sustain pedal lines
     sustain_pedal = [
         dict(
             number=64,
             time=midi_ticks_to_seconds(ped.Time, mpq, ppq),
             value=ped.Value,
+            track=used_track, 
+            channel=used_channel,
         )
         for ped in mf.sustain_pedal
     ]
@@ -395,16 +414,11 @@ def performed_part_from_match(
             number=67,
             time=midi_ticks_to_seconds(ped.Time, mpq, ppq),
             value=ped.Value,
+            track=used_track,
+            channel=used_channel,
         )
         for ped in mf.soft_pedal
     ]
-
-    # check if multiple tracks are in the match file
-    if len(tracks) > 1:
-        warnings.warn(
-                "multiple MIDI tracks in matchfile" "information!."
-            )
-    used_track = min(tracks)
 
     # Make performed part
     ppart = PerformedPart(

--- a/partitura/performance.py
+++ b/partitura/performance.py
@@ -8,6 +8,7 @@ notes as well as continuous control parameters, such as sustain pedal.
 """
 
 
+from collections import defaultdict
 from typing import Union, List, Optional, Iterator, Iterable as Itertype
 import numpy as np
 from partitura.utils import note_array_from_part_list
@@ -623,33 +624,32 @@ class Performance(object):
         self.performedparts is unique (i.e., that a track number does not appear
         in multiple `PerformedPart` instances)
         """
-        unique_track_ids = list(
-            set(
-                [(i, n.get("track", -1)) for i, pp in enumerate(self) for n in pp.notes]
-                + [
-                    (i, c.get("track", -1))
-                    for i, pp in enumerate(self)
-                    for c in pp.controls
-                ]
-                + [
-                    (i, p.get("track", -1))
-                    for i, pp in enumerate(self)
-                    for p in pp.programs
-                ]
+        possible_track_numbers = [*range(16)]
+        for pp in self:
+            # find all used track numbers in this ppart
+            unique_track_ids = list(
+                set([n.get("track", 0) for n in pp.notes]
+                    + [c.get("track", 0) for c in pp.controls]
+                    + [p.get("track", 0) for p in pp.programs]
+                    + [pp.track])
             )
-        )
+            # check if only one track number was used and if it's free to use
+            if len(unique_track_ids) == 1 and unique_track_ids[0] in possible_track_numbers:
+                assigned_track_number = unique_track_ids[0]
+                possible_track_numbers.remove(assigned_track_number)
 
-        track_map = dict([(tid, ti) for ti, tid in enumerate(unique_track_ids)])
-
-        for i, ppart in enumerate(self):
-            for note in ppart.notes:
-                note["track"] = track_map[(i, note.get("track", -1))]
-
-            for control in ppart.controls:
-                control["track"] = track_map[(i, control.get("track", -1))]
-
-            for program in ppart.programs:
-                program["track"] = track_map[(i, program.get("track", -1))]
+            # assign a free track number otherwise
+            else:
+                assigned_track_number = possible_track_numbers[0]
+                possible_track_numbers.remove(assigned_track_number)
+            # update all track numbers
+            pp.track = assigned_track_number
+            for note in pp.notes:
+                note["track"] = assigned_track_number
+            for control in pp.controls:
+                control["track"] = assigned_track_number
+            for program in pp.programs:
+                program["track"] = assigned_track_number
 
     def __getitem__(self, index: int) -> PerformedPart:
         """Get `Part in the score by index"""


### PR DESCRIPTION
`load_match` produces only one ppart (~ one track), and match notes might have their differing tracks while sustain elements have no track info. in the performance creation partitura may ensure unique tracks. this can introduce strange behavior:
so if we sanitize the tracks: `ensure_unique_tracks=True`
    track numbers of sustain default to 0 
    -> tracks 0 and 1 are in the same ppart
    -> everything gets mapped to the lowest possible track : 0

if we don't: `ensure_unique_tracks=False`
    track numbers of sustain should default to 0
    track numbers of notes should still be 1

solution:
match file loading is only based on one ppart, so disabling ensure_unique_tracks=False. makes sure that the output of a matchfile that's been loaded into a performance and back to a matchfile still looks the same (and doesn't map all tracks to 0). 
I added a warning if there are multiple tracks though.

I also fixed the track number sanitization code which didn't work.
