### PR TITLE
Round ticks in `save_score_midi`

### DIFF
--- a/partitura/io/exportmidi.py
+++ b/partitura/io/exportmidi.py
@@ -395,7 +395,7 @@ def save_score_midi(
 
         def to_ppq(t):
             # convert div times to new ppq
-            return int(ppq * (qm(t) - ftp))
+            return round(ppq * (qm(t) - ftp))
 
         for tp in part.iter_all(score.Tempo):
             tempos[to_ppq(tp.start.t)] = MetaMessage(


### PR DESCRIPTION
Hi,

This PR fixes a bug that causes incorrect MIDI ticks in some scores saved as MIDI files.

I have attached an archive containing a `score.mxl` file on which the issue persists. The statement `ppq * (qm(t) - ftp)` sometimes produces numbers like `x.9999999`, which are truncated to `x` rather than being rounded to `x + 1` as expected. Consequently, some notes are shorter or longer than in the original score.

The same issue with round might probably be relevant to other parts of the package. However, I haven't checked all the `int()` calls.

[example.zip](https://github.com/user-attachments/files/20674167/example.zip)

<img width="851" alt="image" src="https://github.com/user-attachments/assets/7bdf7e15-10fa-49d4-b87d-268704837e98" />
