### PR TITLE
Remove hardcoded recursion limits that prevented unfolding complex scores

### DIFF
--- a/partitura/score.py
+++ b/partitura/score.py
@@ -5330,6 +5330,10 @@ def unfold_part_maximal(score: ScoreLike, update_ids=True, ignore_leaps=True):
     part where all segments marked with repeat signs are included
     twice.
 
+    Note that for complex scores, this function might raise a RecursionError.
+    The recursion limit can be manually increased beforehand with the function
+    sys.setrecursionlimit.
+
     Parameters
     ----------
     score : ScoreLike
@@ -5351,13 +5355,10 @@ def unfold_part_maximal(score: ScoreLike, update_ids=True, ignore_leaps=True):
 
     """
     if isinstance(score, Score):
-        # Copy needs to be deep, otherwise the recursion limit will be exceeded
-        old_recursion_depth = sys.getrecursionlimit()
-        sys.setrecursionlimit(10000)
+        # Copy needs to be deep, which might trigger a RecursionError for complexes scores
+        # The user is responsible for manually increasing the recursion limit if needed
         # Deep copy of score
         new_score = deepcopy(score)
-        # Reset recursion limit to previous value to avoid side effects
-        sys.setrecursionlimit(old_recursion_depth)
         new_partlist = list()
         for score in new_score.parts:
             unfolded_part = unfold_part_maximal(
@@ -5383,6 +5384,10 @@ def unfold_part_minimal(score: ScoreLike):
     Warning: The unfolding of repeats is computed part-wise, inconsistent repeat markings of parts of a single result
     in inconsistent unfoldings.
 
+    Note that for complex scores, this function might raise a RecursionError.
+    The recursion limit can be manually increased beforehand with the function
+    sys.setrecursionlimit.
+
     Parameters
     ----------
     score: ScoreLike
@@ -5395,13 +5400,10 @@ def unfold_part_minimal(score: ScoreLike):
 
     """
     if isinstance(score, Score):
-        # Copy needs to be deep, otherwise the recursion limit will be exceeded
-        old_recursion_depth = sys.getrecursionlimit()
-        sys.setrecursionlimit(10000)
+        # Copy needs to be deep, which might trigger a RecursionError for complexes scores
+        # The user is responsible for manually increasing the recursion limit if needed
         # Deep copy of score
         unfolded_score = deepcopy(score)
-        # Reset recursion limit to previous value to avoid side effects
-        sys.setrecursionlimit(old_recursion_depth)
         new_partlist = list()
         for part in unfolded_score.parts:
             unfolded_part = unfold_part_minimal(part)

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -5355,9 +5355,8 @@ def unfold_part_maximal(score: ScoreLike, update_ids=True, ignore_leaps=True):
 
     """
     if isinstance(score, Score):
-        # Copy needs to be deep, which might trigger a RecursionError for complexes scores
+        # Copy needs to be deep, which might trigger a RecursionError for complex scores
         # The user is responsible for manually increasing the recursion limit if needed
-        # Deep copy of score
         new_score = deepcopy(score)
         new_partlist = list()
         for score in new_score.parts:
@@ -5400,9 +5399,8 @@ def unfold_part_minimal(score: ScoreLike):
 
     """
     if isinstance(score, Score):
-        # Copy needs to be deep, which might trigger a RecursionError for complexes scores
+        # Copy needs to be deep, which might trigger a RecursionError for complex scores
         # The user is responsible for manually increasing the recursion limit if needed
-        # Deep copy of score
         unfolded_score = deepcopy(score)
         new_partlist = list()
         for part in unfolded_score.parts:


### PR DESCRIPTION
A similar issue was already fixed in #449, but I've found a couple of other occurences of the same problem.

Currently, unfolding a score needs to make a deep copy of the score. For complex scores, this can quickly lead to `RecursionError`s, which is probably the reason why the line`sys.setrecursionlimit(10000)` have been added in the first place.

However, this value of 10000 is completely arbitrary, are can even cause more issues. If a score is too complex (e.g. [Liszt/Mephisto_Waltz](https://github.com/CPJKU/asap-dataset/blob/main/Liszt/Mephisto_Waltz/xml_score.musicxml)), the code will systematically fail with a `RecursionError`, as 10000 is not enough to deep copy it. And the user can't even increase the recursion limit themselves, because it will be overridden by 10000 anyway before the copy.

I therefore chose to remove completely the limit, and to add a simple comment in the docstring stating that this function might raise a `RecursionError` for complex scores, and that the user might want to increase the recursion limit beforehand.

I also thought about catching the recursion error to add a more meaningful message:
```py
try:
    new_score = deepcopy(score)
except RecursionError:
    raise RecursionError(
        "This score is too complex to be deep copied with the current recursion limit. "
        "Consider increasing it with sys.setrecursionlimit."
    )
```
but I finally considered the docstring would be enough. Let me know if you would rather have it, I'll add it.