### PR TITLE
Fix some reference issues when creating a ScoreVariant

### DIFF
--- a/partitura/score.py
+++ b/partitura/score.py
@@ -1845,13 +1845,13 @@ class GenericNote(TimedObject):
         # maintain a list of attributes to update when cloning this instance
         self._ref_attrs.extend(
             [
+                "fermata",
                 "tie_prev",
                 "tie_next",
                 "slur_stops",
                 "slur_starts",
                 "tuplet_stops",
                 "tuplet_starts",
-                "fermata",
             ]
         )
 

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -2194,6 +2194,8 @@ class UnpitchedNote(GenericNote):
         if self.beam is not None:
             self.beam.append(self)
 
+        self._ref_attrs.append("beam")
+
     def __str__(self):
         return " ".join(
             (

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -1851,6 +1851,7 @@ class GenericNote(TimedObject):
                 "slur_starts",
                 "tuplet_stops",
                 "tuplet_starts",
+                "fermata",
             ]
         )
 
@@ -2117,6 +2118,7 @@ class Note(GenericNote):
         self.octave = octave
         self.alter = alter
         self.beam = None
+        self._ref_attrs.append("beam")
 
     def assign_beam(self, beam):
         self.beam = beam
@@ -2228,6 +2230,7 @@ class Beam(TimedObject):
         super().__init__()
         self.id = id
         self.notes = []
+        self._ref_attrs.append("notes")
 
     def append(self, note):
         note.beam = self
@@ -2676,6 +2679,7 @@ class Fermata(TimedObject):
         super().__init__()
         # ref(erent) can be a note or a barline
         self.ref = ref
+        self._ref_attrs.append("ref")
 
     def __str__(self):
         return f"{super().__str__()} ref={self.ref}"


### PR DESCRIPTION
Closes #450.

This PR adds a couple of attributes that were not correctly handled when a `ScoreVariant` would be produced, resulting in `RecursionError`s (and even segmentation faults with some scores) when trying to pickle some unfolded scores:
```py
import warnings
from pathlib import Path
import pickle
import sys
import partitura as pt
import partitura.score

sys.setrecursionlimit(2**31-1)

score_path = Path("~/Documents/datasets/asap-dataset/Liszt/Sonata/xml_score.musicxml").expanduser()

with warnings.catch_warnings():
    warnings.simplefilter("ignore")
    score = pt.load_musicxml(score_path)
    score = pt.score.unfold_part_maximal(score)
with open("/tmp/test.pkl", "wb") as f:
    pickle.dump(score, f)
# Segmentation fault (core dumped)
```

The added references are the following:
- `GenericNote.fermata`
- `Note.beam`
- `UnpitchedNote.beam`
- `Beam.notes`
- `Fermata.ref`  **EDIT: Seems problematic, see comment below**

Before, those attributes were not updated during the creation of a `ScoreVariant`, resulting in them pointing to the elements in the original score. Now, the references are correctly updated to point to the corresponding elements in the created `ScoreVariant`.