### PR TITLE
adds `pathlib.Path` objects as `PathLike`

### DIFF
--- a/partitura/utils/misc.py
+++ b/partitura/utils/misc.py
@@ -9,7 +9,7 @@ import warnings
 from urllib.request import urlopen
 from shutil import copyfileobj
 import re
-
+from pathlib import Path
 from typing import Union, Callable, Dict, Any, Iterable, Optional, List
 
 import numpy as np
@@ -25,7 +25,7 @@ except ImportError:
     PIL_EXISTS = False
 
 # Recommended by PEP 519
-PathLike = Union[str, bytes, os.PathLike]
+PathLike = Union[str, bytes, os.PathLike, Path]
 
 
 def get_document_name(filename: PathLike) -> str:


### PR DESCRIPTION
Currently, the (local to Partitura) `PathLike` check accepts only `str`, `bytes`, and `os.PathLike`.

This PR proposes the addition of `pathlib.Path` objects.

The consequence of non-inclusion in this `PathLike` list is attempting handling as an URL (`io/__init__`) which leads to less-than-ideal error messages. 

This PR is limited to the case of `pathlib.Path` objects; in another PR it might be worth additional work on the modular handling of further types and/or the real case of URLs.