### PR TITLE
Revert "adds `pathlib.Path` objects as `PathLike`"

### DIFF
--- a/partitura/utils/misc.py
+++ b/partitura/utils/misc.py
@@ -9,7 +9,7 @@ import warnings
 from urllib.request import urlopen
 from shutil import copyfileobj
 import re
-from pathlib import Path
+
 from typing import Union, Callable, Dict, Any, Iterable, Optional, List
 
 import numpy as np
@@ -25,7 +25,7 @@ except ImportError:
     PIL_EXISTS = False
 
 # Recommended by PEP 519
-PathLike = Union[str, bytes, os.PathLike, Path]
+PathLike = Union[str, bytes, os.PathLike]
 
 
 def get_document_name(filename: PathLike) -> str:


### PR DESCRIPTION
Reverts CPJKU/partitura#463

Due to an oversight on my end, pull request #463 was merged to `main` rather than `develop`. This patch reverts to the previous state. The pull request will be reopened and merged to `develop`.