### PR TITLE
Reapply adding `pathlib.Path` to `Pathlike`

### DIFF
--- a/partitura/utils/misc.py
+++ b/partitura/utils/misc.py
@@ -9,7 +9,7 @@ import warnings
 from urllib.request import urlopen
 from shutil import copyfileobj
 import re
-
+from pathlib import Path
 from typing import Union, Callable, Dict, Any, Iterable, Optional, List
 
 import numpy as np
@@ -25,7 +25,7 @@ except ImportError:
     PIL_EXISTS = False
 
 # Recommended by PEP 519
-PathLike = Union[str, bytes, os.PathLike]
+PathLike = Union[str, bytes, os.PathLike, Path]
 
 
 def get_document_name(filename: PathLike) -> str:


### PR DESCRIPTION
This PR restores PR #463, but this time to the `develop` branch instead of `main`, to be consistent with the regular development cycle. 