### PR TITLE
Allow parsing mxl when using Pathlib

### DIFF
--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -5,6 +5,7 @@ This module contains methods for importing MusicXML files.
 """
 
 import os
+from pathlib import Path
 import warnings
 import zipfile
 
@@ -233,7 +234,7 @@ def load_musicxml(
         )
 
     xml = None
-    if isinstance(filename, str):
+    if isinstance(filename, str | Path):
         if zipfile.is_zipfile(filename):
             with zipfile.ZipFile(filename) as zipped_xml:
                 contained_xml_name = zipped_xml.namelist()[-1]


### PR DESCRIPTION
Partitura MusicXML import currently only allows decompressing mxl files when the path is provided as a string. This PR simply triggers the decompression mechanism also when a pathlib object is passed.