### PR TITLE
configurable aggregation function

### DIFF
--- a/partitura/musicanalysis/performance_codec.py
+++ b/partitura/musicanalysis/performance_codec.py
@@ -720,7 +720,7 @@ def get_time_maps_from_alignment(
     spart_or_note_array, 
     alignment, 
     remove_ornaments=True,
-    onset_aggregation_fun=np.mean
+    onset_aggregation_fun=np.mean,
 ):
     """
     Get time maps to convert performance time (in seconds) to score time (in beats)


### PR DESCRIPTION
this PR addresses:
- a small bug in `get_time_maps_from_alignment` where score onsets without non-ornament notes lead to nan values
- a feature extension of the same function where a new argument can set the function used to aggregate multiple performed onset times corresponding to a single score onset into one time (examples are average=np.mean, earliest=np.min, latest=np.max).