### PR TITLE
Fix note shifting issue #483

### DIFF
--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -598,8 +598,10 @@ def _handle_measure(
             if print_obj == "no" or (notehead is not None and notehead.text == "none"):
                 # Still update position for invisible notes (to avoid problems with backups)
                 if e.tag == "note":
-                    duration = get_value_from_tag(e, "duration", int) or 0
-                    position += duration
+                    chord = e.find("chord")
+                    if chord is None:
+                        duration = get_value_from_tag(e, "duration", int) or 0
+                        position += duration
                 # Skip the object
                 continue
 


### PR DESCRIPTION
This small change in load_musicxml fixes a bug where onsets were wrongly shifted when disallowing invisible notes #483 .
The problem was that invisble *chord* notes ([<chord/>](https://www.w3.org/2021/06/musicxml40/musicxml-reference/examples/chord-element/)), which inherit the starting point and duration of their previous note and do not shift the position, were handled as normal notes and shifted the position further to the right. Simply checking for chord elements seems to solve it for the test file mentioned in the issue. 