### PR TITLE
fix bug in performance note array from score

### DIFF
--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -2968,7 +2968,7 @@ def performance_notearray_from_score_notearray(
             )
 
         p_onsets = np.r_[0, np.cumsum(iois * bp[:-1])]
-        pnote_array["duration_sec"] = bp_duration * snote_array["duration_beat"]
+        pnote_array["duration_sec"] = bp_duration
 
     else:
         # convert bpm to beat period


### PR DESCRIPTION
This is a bug fix in `partitura.performance_notearray_from_score_notearray` method where the `duration_beat` value gets multiplied twice during the duration calculation process. This causes notes with beats less than 1 to render shorter and notes with beats greater than 1 to render longer. Consequently, legato passages often sound staccato in many songs. 