### PR TITLE
fix to use samplerate when initializing fluidsynth

### DIFF
--- a/partitura/utils/fluidsynth.py
+++ b/partitura/utils/fluidsynth.py
@@ -171,7 +171,7 @@ def synthesize_fluidsynth(
             ]
 
     # set to mono
-    synthesizer = Synth(samplerate=SAMPLE_RATE)
+    synthesizer = Synth(samplerate=samplerate)
     sf_id = synthesizer.sfload(soundfont)
 
     audio_signals = []


### PR DESCRIPTION
This fixes a bug where sample rates other than 44.1kHz were not applied when using `partitura.save_wav_fluidsynth`.