### PR TITLE
Enhancement: Add 'local_grace_order' field to score note array when include_grace_notes

### DIFF
--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -1337,10 +1337,14 @@ def _handle_note(e, position, part, ongoing, prev_note, doc_order, prev_beam=Non
     # code in handle_tuplet function)
 
     chord = e.find("chord")
+    is_grace_chord = False
     if chord is not None:
         # this note starts at the same position as the previous note, and has
         # same duration
         assert prev_note is not None
+        is_grace_chord = True
+        if prev_note.is_grace_chord == False:
+            prev_note.is_grace_chord = True
         position = prev_note.start.t
         duration = prev_note.duration
         duration_from_symbolic = prev_note.duration_from_symbolic
@@ -1394,6 +1398,7 @@ def _handle_note(e, position, part, ongoing, prev_note, doc_order, prev_beam=Non
                 steal_proportion=steal_proportion,
                 doc_order=doc_order,
                 stem_direction=stem_dir,
+                is_grace_chord=is_grace_chord,
             )
             if isinstance(prev_note, score.GraceNote) and prev_note.voice == voice:
                 note.grace_prev = prev_note
@@ -1432,6 +1437,7 @@ def _handle_note(e, position, part, ongoing, prev_note, doc_order, prev_beam=Non
                 technical=technical_notations,
                 doc_order=doc_order,
                 stem_direction=stem_dir,
+                is_grace_chord=is_grace_chord,
             )
 
         if isinstance(prev_note, score.GraceNote) and prev_note.voice == voice:

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -2111,11 +2111,12 @@ class Note(GenericNote):
 
     """
 
-    def __init__(self, step, octave, alter=None, **kwargs):
+    def __init__(self, step, octave, alter=None, is_grace_chord=False, **kwargs):
         super().__init__(**kwargs)
         self.step = step.upper()
         self.octave = octave
         self.alter = alter
+        self.is_grace_chord = is_grace_chord
         self.beam = None
 
     def assign_beam(self, beam):

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -3700,7 +3700,7 @@ def expand_grace_notes_from_local_grace_order(
         
         if len(grace_notes_at_onset) > 0:
             # get the grace_type of the grace notes at this onset
-            grace_types = grace_notes_at_onset['grace_type']
+            grace_types = set(grace_notes_at_onset['grace_type'])
             for grace_type in grace_types:
                 grace_notes_at_onset_and_type = grace_notes_at_onset[grace_notes_at_onset['grace_type'] == grace_type]
                 # sort the grace notes at this onset and type by their local_grace_order in ascending order
@@ -3740,11 +3740,11 @@ def expand_grace_notes_from_local_grace_order(
                         for row in grace_notes_at_onset_and_type_and_staff:
                             # update the values in the score_note_array for this grace note given the id value
                             score_note_array['onset_beat'][score_note_array['id'] == row['id']] = onset + duration_per_appoggiatura * row['local_grace_order'] * ts_beat_type/4
-                            score_note_array['duration_beat'][score_note_array['id'] == row['id']] = duration_per_appoggiatura * ts_beat_type/4
+                            score_note_array['duration_beat'][score_note_array['id'] == row['id']] += duration_per_appoggiatura * ts_beat_type/4
                             score_note_array['onset_quarter'][score_note_array['id'] == row['id']] = onset + duration_per_appoggiatura * row['local_grace_order']
-                            score_note_array['duration_quarter'][score_note_array['id'] == row['id']] = duration_per_appoggiatura
+                            score_note_array['duration_quarter'][score_note_array['id'] == row['id']] += duration_per_appoggiatura
                             score_note_array['onset_div'][score_note_array['id'] == row['id']] = ((onset + duration_per_appoggiatura * row['local_grace_order']) * row['divs_pq']).astype(int)
-                            score_note_array['duration_div'][score_note_array['id'] == row['id']] = (duration_per_appoggiatura * row['divs_pq']).astype(int)
+                            score_note_array['duration_div'][score_note_array['id'] == row['id']] += (duration_per_appoggiatura * row['divs_pq']).astype(int)
 
                     else: # acciaccatura
                         previous_non_grace_notes_at_staff_and_onset = score_note_array[
@@ -3789,11 +3789,11 @@ def expand_grace_notes_from_local_grace_order(
                         for row in grace_notes_at_onset_and_type_and_staff:
                             # update the values in the score_note_array for this grace note given the id value
                             score_note_array['onset_beat'][score_note_array['id'] == row['id']] = prev_onset_beat + duration_per_acciaccatura * (row['local_grace_order']) * ts_beat_type/4
-                            score_note_array['duration_beat'][score_note_array['id'] == row['id']] = duration_per_acciaccatura * ts_beat_type/4
+                            score_note_array['duration_beat'][score_note_array['id'] == row['id']] += duration_per_acciaccatura * ts_beat_type/4
                             score_note_array['onset_quarter'][score_note_array['id'] == row['id']] = prev_onset_quarter + duration_per_acciaccatura * (row['local_grace_order'])
-                            score_note_array['duration_quarter'][score_note_array['id'] == row['id']] = duration_per_acciaccatura
+                            score_note_array['duration_quarter'][score_note_array['id'] == row['id']] += duration_per_acciaccatura
                             score_note_array['onset_div'][score_note_array['id'] == row['id']] = ((prev_onset_div + duration_per_acciaccatura * (row['local_grace_order'])) * row['divs_pq']).astype(int)
-                            score_note_array['duration_div'][score_note_array['id'] == row['id']] = (duration_per_acciaccatura * row['divs_pq']).astype(int)
+                            score_note_array['duration_div'][score_note_array['id'] == row['id']] += (duration_per_acciaccatura * row['divs_pq']).astype(int)
 
         
         # update the previous_non_grace_notes for this staff to be the current main non-grace notes at this onset and staff

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -2535,6 +2535,7 @@ def note_array_from_note_list(
             steal_proportion = -1.0
             is_grace_chord = False
             local_grace_order = -1
+            doc_order = note.doc_order if hasattr(note, "doc_order") else -1
             if is_grace:
                 grace_type = note.grace_type
                 local_grace_order = 0
@@ -2549,7 +2550,7 @@ def note_array_from_note_list(
                 grace_type = ""
 
             
-            note_info += (is_grace, grace_type, steal_proportion, local_grace_order, is_grace_chord, note.doc_order)
+            note_info += (is_grace, grace_type, steal_proportion, local_grace_order, is_grace_chord, doc_order)
 
 
         if key_signature_map is not None:
@@ -2597,7 +2598,7 @@ def note_array_from_note_list(
     note_array = note_array[onset_sort_idx]
 
     if include_grace_notes:
-        # Compute local grace order for each group of grace notes with the same onset time and voice. Modify the note array in place
+        # Compute local grace order for each group of grace notes with the same onset time and voice.
         unique_onsets = np.unique(note_array[onset_unit])
         for onset in unique_onsets:
             onset_array = note_array[note_array[onset_unit] == onset]

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -2473,6 +2473,8 @@ def note_array_from_note_list(
     # fields for grace notes
     if include_grace_notes:
         fields += [("is_grace", "b"), ("grace_type", "U256"), ("steal_proportion", "f4"), ("local_grace_order", "i4"), ("is_grace_chord", "b"), ("doc_order", "i4")]
+        if not include_staff:
+            fields += [("staff", "i4")]
 
     # fields for key signature
     if key_signature_map is not None:
@@ -2562,6 +2564,9 @@ def note_array_from_note_list(
 
             
             note_info += (is_grace, grace_type, steal_proportion, local_grace_order, is_grace_chord, doc_order)
+            if not include_staff:
+                 staff = note.staff if note.staff is not None else 0
+                 note_info += (staff,)
 
 
         if key_signature_map is not None:
@@ -2615,14 +2620,15 @@ def note_array_from_note_list(
             onset_array = note_array[note_array[onset_unit] == onset]
             grace_onset_array = onset_array[onset_array["is_grace"] == 1]
             if len(grace_onset_array) > 0:
-                unique_voices = np.unique(grace_onset_array["voice"])
-                for voice in unique_voices:
-                    voice_grace_onset_array = grace_onset_array[grace_onset_array["voice"] == voice]
-                    min_doc_order = voice_grace_onset_array["doc_order"].min()
-                    unique_nids = np.unique(voice_grace_onset_array["id"])
+                unique_staffs = np.unique(grace_onset_array["staff"])
+                for staff in unique_staffs:
+                    staff_grace_onset_array = grace_onset_array[grace_onset_array["staff"] == staff]
+                    # sort by document order
+                    staff_grace_onset_array = staff_grace_onset_array[np.argsort(staff_grace_onset_array["doc_order"])]
                     local_order_val = 0
                     chord_flag = False
-                    for nid in unique_nids:
+                    for row in staff_grace_onset_array:
+                        nid = row["id"]
                         row_idx = np.where((note_array["id"] == nid))[0]
                         if note_array[row_idx]["is_grace_chord"] == True:
                             chord_flag = True
@@ -2637,6 +2643,8 @@ def note_array_from_note_list(
 
         note_array = np.lib.recfunctions.drop_fields(note_array, "is_grace_chord")
         note_array = np.lib.recfunctions.drop_fields(note_array, "doc_order")
+        if not include_staff:
+            note_array = np.lib.recfunctions.drop_fields(note_array, "staff")
 
     return note_array
 

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -3636,6 +3636,220 @@ def segment_ppart_by_gap(
     return list_pparts, start_end_times
 
 
+def ensure_grace_duration(
+        main_note_array: np.ndarray, 
+        grace_offset_quarter: float,
+        ) -> float:
+    '''
+    Ensure that the grace offset is less than the minimum duration of the main notes, 
+    otherwise reduce the grace offset by half until it is less than the minimum duration of the main notes.
+    The main notes are the non-grace notes that are immediately preceded by the grace notes, and that are on the same staff as the grace notes.
+    '''
+
+    if main_note_array is None or len(main_note_array) == 0:
+        return grace_offset_quarter
+    while main_note_array['duration_quarter'].min() <= grace_offset_quarter:
+        print("Warning: The minimum duration of the main note is less than or equal to the grace offset. Reducing the grace offset by half.")
+        grace_offset_quarter /= 2
+    return grace_offset_quarter
+
+
+def expand_grace_notes_from_local_grace_order(
+        score_part: Any,
+        grace_offset_quarter: float = 1/4,
+        ) -> np.ndarray:
+    '''
+    Expand grace notes by time and duration in the score note array based on their local grace order.
+    If the grace notes have the 'acciaccatura' grace_type, then they expand backwards in time. 
+    If the grace notes have the 'appoggiatura' grace_type, then they expand forwards in time.
+    All the grace notes within an acciaccatura or appoggiatura group are given a cumulative duration of grace_offset_quarter, 
+    where a grace_offset_quarter value of 1/4 means a duration of a 16th note.
+    This means that if there are 2 grace notes in an acciaccatura group, then each grace note will have a duration of 1/8th of a quarter note, 
+    and the onset of the first grace note will be 1/2 of a quarter note before the main note, 
+    and the onset of the second grace note will be 1/4th of a quarter note before the main note.
+    These two notes will 'steal' the time from the previous non-grace note, which will have its duration reduced by 1/4 of a quarter note.
+    In the case of appoggiaturas, the first grace note will have an onset that is the same as the main note,
+    but the main note will have an onset that is 1/4th of a quarter note after the first grace note, 
+    and the second grace note will have an onset that is 1/8th of a quarter note after the first grace note.
+    
+    Parameters
+    ----------
+    score_part: Part
+        A Partitura Score Part object from which a note array is to be generated with expanded the grace notes.
+    grace_offset_quarter: float
+        The cumulative duration in quarter notes that the grace notes at a given onset and staff will have.
+
+    Returns
+    -------
+    score_note_array: np.ndarray
+        A note array with the grace notes expanded by time and duration based on their local grace order.
+    '''
+
+    score_note_array = score_part.note_array(include_staff=True, include_grace_notes=True, include_time_signature=True, include_divs_per_quarter=True)
+    unique_onsets = np.unique(score_note_array['onset_beat'])
+    min_onset = score_note_array['onset_beat'].min()
+    min_onset_previous = min_onset - grace_offset_quarter
+    unique_staffs = np.unique(score_note_array['staff'])
+    previous_onset_staff = {staff: min_onset_previous for staff in unique_staffs}
+
+    for onset in unique_onsets:
+        notes_at_onset = score_note_array[score_note_array['onset_beat'] == onset]
+        # check if there are any grace notes at this onset
+        grace_notes_at_onset = notes_at_onset[notes_at_onset['is_grace'] == True]
+        
+        if len(grace_notes_at_onset) > 0:
+            # get the grace_type of the grace notes at this onset
+            grace_types = grace_notes_at_onset['grace_type']
+            for grace_type in grace_types:
+                grace_notes_at_onset_and_type = grace_notes_at_onset[grace_notes_at_onset['grace_type'] == grace_type]
+                # sort the grace notes at this onset and type by their local_grace_order in ascending order
+                grace_notes_at_onset_and_type = grace_notes_at_onset_and_type[np.argsort(grace_notes_at_onset_and_type['local_grace_order'])]
+               
+                staff_values_at_onset_and_type = np.unique(grace_notes_at_onset_and_type["staff"])
+                
+                for staff_value in staff_values_at_onset_and_type:
+                    grace_notes_at_onset_and_type_and_staff = grace_notes_at_onset_and_type[grace_notes_at_onset_and_type['staff'] == staff_value]
+                
+                    ts_beat_type = grace_notes_at_onset_and_type_and_staff[0]['ts_beat_type']
+                    if grace_type == "appoggiatura":
+                        # get the main non-grace note that is on the same staff as this type of grace note.
+                        # We assume that only one type of grace note can be present at a given onset and staff.
+                        non_grace_notes_at_onset_and_staff = notes_at_onset[(notes_at_onset['is_grace'] == False) & (notes_at_onset['staff'] == staff_value)]
+                        # ensure that the minimum duration of the main non-grace note is greater than the grace offset, otherwise we cannot expand the grace notes
+                        grace_offset_quarter = ensure_grace_duration(non_grace_notes_at_onset_and_staff, grace_offset_quarter)
+
+                        # the main non-grace notes' onset_beat will be delayed by grace_offset_quarter, and the grace notes will be placed before the main non-grace note
+                        # get the "id" values of the main non-grace notes at this onset and staff
+                        non_grace_note_ids = non_grace_notes_at_onset_and_staff['id']
+                        # update the values in the score_note_array for the main non-grace notes at this onset and staff given the id values
+                        for non_grace_note_id in non_grace_note_ids:
+                            score_note_array['onset_beat'][score_note_array['id'] == non_grace_note_id] += grace_offset_quarter * ts_beat_type/4
+                            score_note_array['duration_beat'][score_note_array['id'] == non_grace_note_id] -= grace_offset_quarter * ts_beat_type/4
+                            score_note_array['onset_quarter'][score_note_array['id'] == non_grace_note_id] += grace_offset_quarter
+                            score_note_array['duration_quarter'][score_note_array['id'] == non_grace_note_id] -= grace_offset_quarter
+                            score_note_array['onset_div'][score_note_array['id'] == non_grace_note_id] += (grace_offset_quarter * score_note_array['divs_pq'][score_note_array['id'] == non_grace_note_id]).astype(int)
+                            score_note_array['duration_div'][score_note_array['id'] == non_grace_note_id] -= (grace_offset_quarter * score_note_array['divs_pq'][score_note_array['id'] == non_grace_note_id]).astype(int)
+
+                        # appoggiaturas expand forwards in time
+                        if np.all(grace_notes_at_onset_and_type_and_staff['local_grace_order'] == 0):
+                            duration_per_appoggiatura = grace_offset_quarter
+                        else:
+                            num_of_appogiaturas = np.unique(grace_notes_at_onset_and_type_and_staff['local_grace_order']).shape[0]
+                            duration_per_appoggiatura = grace_offset_quarter / num_of_appogiaturas
+                        for row in grace_notes_at_onset_and_type_and_staff:
+                            # update the values in the score_note_array for this grace note given the id value
+                            score_note_array['onset_beat'][score_note_array['id'] == row['id']] = onset + duration_per_appoggiatura * row['local_grace_order'] * ts_beat_type/4
+                            score_note_array['duration_beat'][score_note_array['id'] == row['id']] = duration_per_appoggiatura * ts_beat_type/4
+                            score_note_array['onset_quarter'][score_note_array['id'] == row['id']] = onset + duration_per_appoggiatura * row['local_grace_order']
+                            score_note_array['duration_quarter'][score_note_array['id'] == row['id']] = duration_per_appoggiatura
+                            score_note_array['onset_div'][score_note_array['id'] == row['id']] = ((onset + duration_per_appoggiatura * row['local_grace_order']) * row['divs_pq']).astype(int)
+                            score_note_array['duration_div'][score_note_array['id'] == row['id']] = (duration_per_appoggiatura * row['divs_pq']).astype(int)
+
+                    else: # acciaccatura
+                        previous_non_grace_notes_at_staff_and_onset = score_note_array[
+                            (score_note_array['is_grace'] == False) & 
+                            (score_note_array['staff'] == staff_value) & 
+                            (score_note_array['onset_beat'] < onset) & 
+                            (score_note_array['onset_beat'] >= previous_onset_staff[staff_value])]
+                        
+                        # modify only the previous non-grace notes that have a note off that is greater than 
+                        # the onset of the current grace notes minus the grace offset.
+                        prev_valid_nids = []
+                        for row in previous_non_grace_notes_at_staff_and_onset:
+                            note_off = row['onset_beat'] + row['duration_beat']
+                            id_val = row['id']
+                            if note_off > onset - grace_offset_quarter * ts_beat_type/4:
+                                prev_valid_nids.append(id_val)
+                        previous_non_grace_notes_at_staff_and_onset = previous_non_grace_notes_at_staff_and_onset[np.isin(previous_non_grace_notes_at_staff_and_onset['id'], prev_valid_nids)]
+                        
+                        # ensure that the minimum duration of the previous main non-grace note is greater than the grace offset, otherwise we cannot expand the grace notes
+                        grace_offset_quarter = ensure_grace_duration(previous_non_grace_notes_at_staff_and_onset, grace_offset_quarter)
+
+                        # get the "id" values of the previous non grace notes on this staff
+                        previous_non_grace_note_ids = previous_non_grace_notes_at_staff_and_onset['id'] if previous_non_grace_notes_at_staff_and_onset is not None else None
+                        if previous_non_grace_note_ids is not None and len(previous_non_grace_note_ids) > 0:
+                            # the previous main non-grace notes' duration_beat will be reduced by grace_offset_quarter, and the grace notes will be placed after the previous main non-grace note
+                            for non_grace_note_id in previous_non_grace_note_ids:
+                                score_note_array['duration_beat'][score_note_array['id'] == non_grace_note_id] -= grace_offset_quarter * ts_beat_type/4
+                                score_note_array['duration_quarter'][score_note_array['id'] == non_grace_note_id] -= grace_offset_quarter
+                                score_note_array['duration_div'][score_note_array['id'] == non_grace_note_id] -= (grace_offset_quarter * score_note_array['divs_pq'][score_note_array['id'] == non_grace_note_id]).astype(int)
+
+                        # acciaccaturas expand backwards in time
+                        if np.all(grace_notes_at_onset_and_type_and_staff['local_grace_order'] == 0):
+                            duration_per_acciaccatura = grace_offset_quarter
+                        else:
+                            num_of_acciaccaturas = np.unique(grace_notes_at_onset_and_type_and_staff['local_grace_order']).shape[0]
+                            duration_per_acciaccatura = grace_offset_quarter / num_of_acciaccaturas
+                        prev_onset_beat = onset - grace_offset_quarter * ts_beat_type/4
+                        current_onset_quarter = grace_notes_at_onset_and_type_and_staff[0]['onset_quarter']
+                        prev_onset_quarter = current_onset_quarter - grace_offset_quarter
+                        current_onset_div = grace_notes_at_onset_and_type_and_staff[0]['onset_div']
+                        prev_onset_div = current_onset_div - (grace_offset_quarter * grace_notes_at_onset_and_type_and_staff[0]['divs_pq']).astype(int)
+                        for row in grace_notes_at_onset_and_type_and_staff:
+                            # update the values in the score_note_array for this grace note given the id value
+                            score_note_array['onset_beat'][score_note_array['id'] == row['id']] = prev_onset_beat + duration_per_acciaccatura * (row['local_grace_order']) * ts_beat_type/4
+                            score_note_array['duration_beat'][score_note_array['id'] == row['id']] = duration_per_acciaccatura * ts_beat_type/4
+                            score_note_array['onset_quarter'][score_note_array['id'] == row['id']] = prev_onset_quarter + duration_per_acciaccatura * (row['local_grace_order'])
+                            score_note_array['duration_quarter'][score_note_array['id'] == row['id']] = duration_per_acciaccatura
+                            score_note_array['onset_div'][score_note_array['id'] == row['id']] = ((prev_onset_div + duration_per_acciaccatura * (row['local_grace_order'])) * row['divs_pq']).astype(int)
+                            score_note_array['duration_div'][score_note_array['id'] == row['id']] = (duration_per_acciaccatura * row['divs_pq']).astype(int)
+
+        
+        # update the previous_non_grace_notes for this staff to be the current main non-grace notes at this onset and staff
+        for staff_val in previous_onset_staff.keys():
+            previous_onset_staff[staff_val] = onset
+
+    # sort the score_note_array by onset_beat and then by id
+    score_note_array = score_note_array[np.lexsort((score_note_array['id'], score_note_array['onset_beat']))]
+
+    return score_note_array
+
+
+def remove_double_notes_from_score(
+    score_part: Any,
+    choose_longer_note: bool = False,
+) -> np.ndarray:
+    '''
+    Remove double notes from the score note array. Double notes are defined as notes that have the same onset time and pitch.
+    Such notes are usually meant for visually indicating an overarching melody within a group of voices/notes.
+    These double notes need to be removed for various applications such as alignment of score and performance/rehearsal.
+    
+    Parameters
+    ----------
+    score_note_array: np.ndarray
+        A note array of the score from which double notes are to be removed.
+    choose_longer_note: bool
+        Whether to choose the longer note among the double notes to keep in the score note array.
+         If False, the shorter note will be kept. The default is False.
+
+    Returns
+    -------
+    score_note_array_no_double: np.ndarray
+        A note array of the score with the double notes removed.
+    '''
+    
+    # get the unique onsets in the score_note_array
+    score_note_array = score_part.note_array(include_grace_notes=True)
+    unique_onsets = np.unique(score_note_array['onset_beat'])
+    score_note_array_no_double = score_note_array.copy()
+    for onset in unique_onsets:
+        notes_at_onset = score_note_array[score_note_array['onset_beat'] == onset]
+        unique_pitches_at_onset = np.unique(notes_at_onset['pitch'])
+        for pitch in unique_pitches_at_onset:
+            notes_at_onset_and_pitch = notes_at_onset[notes_at_onset['pitch'] == pitch]
+            non_grace_notes_at_onset_and_pitch = notes_at_onset_and_pitch[notes_at_onset_and_pitch['is_grace'] == False]
+            if len(non_grace_notes_at_onset_and_pitch) > 1:
+                if choose_longer_note:
+                    note_to_keep = non_grace_notes_at_onset_and_pitch[np.argmax(non_grace_notes_at_onset_and_pitch['duration_beat'])]
+                else:
+                    note_to_keep = non_grace_notes_at_onset_and_pitch[np.argmin(non_grace_notes_at_onset_and_pitch['duration_beat'])]
+                
+                note_to_remove = non_grace_notes_at_onset_and_pitch[non_grace_notes_at_onset_and_pitch != note_to_keep]
+                score_note_array_no_double = score_note_array_no_double[score_note_array_no_double != note_to_remove]
+
+    return score_note_array_no_double
+
+
 if __name__ == "__main__":
     import doctest
 

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -3657,6 +3657,7 @@ def ensure_grace_duration(
 def expand_grace_notes_from_local_grace_order(
         score_part: Any,
         grace_offset_quarter: float = 1/4,
+        **kwargs,
         ) -> np.ndarray:
     '''
     Expand grace notes by time and duration in the score note array based on their local grace order.
@@ -3685,7 +3686,7 @@ def expand_grace_notes_from_local_grace_order(
         A note array with the grace notes expanded by time and duration based on their local grace order.
     '''
 
-    score_note_array = score_part.note_array(include_staff=True, include_grace_notes=True, include_time_signature=True, include_divs_per_quarter=True)
+    score_note_array = score_part.note_array(include_staff=True, include_grace_notes=True, include_time_signature=True, include_divs_per_quarter=True, **kwargs)
     unique_onsets = np.unique(score_note_array['onset_beat'])
     min_onset = score_note_array['onset_beat'].min()
     min_onset_previous = min_onset - grace_offset_quarter
@@ -3833,7 +3834,7 @@ def remove_double_notes_from_score_note_array(
     '''
 
     if 'is_grace' not in score_note_array.dtype.names:
-        raise ValueError("The score_note_array must have the 'is_grace' column in order to remove double notes correctly.")
+        raise ValueError("The score_note_array must have the 'is_grace' column in order to remove double notes correctly. Pass the 'include_grace_notes=True' argument when generating the score_note_array to include the 'is_grace' column.")
     
     # get the unique onsets in the score_note_array
     unique_onsets = np.unique(score_note_array['onset_beat'])

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -3851,8 +3851,9 @@ def remove_double_notes_from_score_note_array(
                 else:
                     note_to_keep = non_grace_notes_at_onset_and_pitch[np.argmin(non_grace_notes_at_onset_and_pitch['duration_beat'])]
                 
-                note_to_remove = non_grace_notes_at_onset_and_pitch[non_grace_notes_at_onset_and_pitch != note_to_keep]
-                score_note_array_no_double = score_note_array_no_double[score_note_array_no_double != note_to_remove]
+                notes_to_remove = non_grace_notes_at_onset_and_pitch[non_grace_notes_at_onset_and_pitch != note_to_keep]
+                for note_to_remove in notes_to_remove:
+                    score_note_array_no_double = score_note_array_no_double[score_note_array_no_double != note_to_remove]
 
     return score_note_array_no_double
 

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -2429,6 +2429,8 @@ def note_array_from_note_list(
               is `True`.
             * 'is_grace' : Is the note a grace note. Yes if true.
             * 'grace_type' : The type of grace note. "" for non grace notes.
+            * 'steal_proportion' : The proportion of the duration that the grace 
+              note steals from the neighbouring note.
             * 'local_grace_order' : The document order of the grace notes with 
               the same onset time. -1 for non grace notes.
             * 'ks_fifths': Fifths starting from C in the circle of fifths.
@@ -2468,7 +2470,7 @@ def note_array_from_note_list(
     if include_pitch_spelling:
         fields += [("step", "U256"), ("alter", "i4"), ("octave", "i4")]
 
-    # fields for pitch spelling
+    # fields for grace notes
     if include_grace_notes:
         fields += [("is_grace", "b"), ("grace_type", "U256"), ("steal_proportion", "f4"), ("local_grace_order", "i4"), ("is_grace_chord", "b"), ("doc_order", "i4")]
 
@@ -2535,7 +2537,14 @@ def note_array_from_note_list(
             steal_proportion = -1.0
             is_grace_chord = False
             local_grace_order = -1
-            doc_order = note.doc_order if hasattr(note, "doc_order") else -1
+
+            if hasattr(note, "doc_order"):
+                doc_order = note.doc_order
+                if doc_order is None:
+                    doc_order = -1
+            else:
+                doc_order = -1
+                
             if is_grace:
                 grace_type = note.grace_type
                 local_grace_order = 0
@@ -2545,6 +2554,8 @@ def note_array_from_note_list(
                         steal_proportion = -1.0
                 if hasattr(note, "is_grace_chord"):
                     is_grace_chord = note.is_grace_chord
+                    if is_grace_chord is None:
+                        is_grace_chord = False
 
             else:
                 grace_type = ""

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -2128,7 +2128,8 @@ def note_array_from_part(
         Default is False
     include_grace_notes : bool (optional)
         If `True`,  includes grace note information, i.e. if a note is a
-        grace note and the grace type "" for non grace notes).
+        grace note, the document order of the grace notes with the same onset 
+        and the grace type "" for non grace notes).
         Default is False
     include_staff : bool (optional)
         If `True`,  includes staff information
@@ -2176,12 +2177,16 @@ def note_array_from_part(
         If 'include_grace_notes' is True:
             * 'is_grace': 1 if the note is a grace 0 otherwise
             * 'grace_type' : the type of the grace notes "" for non grace notes
+            * 'local_grace_order' : the document order of the grace notes with the same onset 
+              (-1 for non grace notes)
 
         If 'include_staff' is True:
             * 'staff' : the staff number for each note
 
         If 'include_divs_per_quarter' is True:
             * 'divs_pq': the number of divs per quarter note
+
+    
     Examples
     --------
     >>> from partitura import load_musicxml, EXAMPLE_MUSICXML
@@ -2385,8 +2390,9 @@ def note_array_from_note_list(
         note. Default is False
     include_grace_notes : bool (optional)
         If `True`,  includes grace note information, i.e. if a note is a
-        grace note has one of the types "appoggiatura, acciaccatura, grace" and
-        the grace type "" for non grace notes).
+        grace note and has one of the types "appoggiatura, acciaccatura, grace" and
+        the grace type "" for non grace notes. 
+        It also includes the local grace note document order).
         Default is False
     include_staff : bool (optional)
         If `True`,  includes the staff number for every note.
@@ -2395,7 +2401,6 @@ def note_array_from_note_list(
         The number of divs (e.g. MIDI ticks, MusicXML ppq) per quarter
         note of the current part.
         Default is None
-
 
     Returns
     -------
@@ -2424,6 +2429,8 @@ def note_array_from_note_list(
               is `True`.
             * 'is_grace' : Is the note a grace note. Yes if true.
             * 'grace_type' : The type of grace note. "" for non grace notes.
+            * 'local_grace_order' : The document order of the grace notes with 
+              the same onset time. -1 for non grace notes.
             * 'ks_fifths': Fifths starting from C in the circle of fifths.
               Included if `key_signature_map` is not `None`.
             * 'mode': major or minor. Included If `key_signature_map` is
@@ -2463,7 +2470,7 @@ def note_array_from_note_list(
 
     # fields for pitch spelling
     if include_grace_notes:
-        fields += [("is_grace", "b"), ("grace_type", "U256")]
+        fields += [("is_grace", "b"), ("grace_type", "U256"), ("steal_proportion", "f4"), ("local_grace_order", "i4"), ("is_grace_chord", "b"), ("doc_order", "i4")]
 
     # fields for key signature
     if key_signature_map is not None:
@@ -2487,6 +2494,7 @@ def note_array_from_note_list(
     # field for divs_pq
     if divs_per_quarter:
         fields += [("divs_pq", "i4")]
+
 
     note_array = []
     for note in note_list:
@@ -2524,11 +2532,25 @@ def note_array_from_note_list(
 
         if include_grace_notes:
             is_grace = hasattr(note, "grace_type")
+            steal_proportion = -1.0
+            is_grace_chord = False
+            local_grace_order = -1
             if is_grace:
                 grace_type = note.grace_type
+                local_grace_order = 0
+                if hasattr(note, "steal_proportion"):
+                    steal_proportion = note.steal_proportion
+                    if steal_proportion is None:
+                        steal_proportion = -1.0
+                if hasattr(note, "is_grace_chord"):
+                    is_grace_chord = note.is_grace_chord
+
             else:
                 grace_type = ""
-            note_info += (is_grace, grace_type)
+
+            
+            note_info += (is_grace, grace_type, steal_proportion, local_grace_order, is_grace_chord, note.doc_order)
+
 
         if key_signature_map is not None:
             fifths, mode = key_signature_map(note.start.t)
@@ -2552,6 +2574,7 @@ def note_array_from_note_list(
 
         if divs_per_quarter:
             note_info += (divs_per_quarter,)
+            
 
         note_array.append(note_info)
 
@@ -2572,6 +2595,36 @@ def note_array_from_note_list(
     note_array = note_array[pitch_sort_idx]
     onset_sort_idx = np.argsort(note_array[onset_unit], kind="mergesort")
     note_array = note_array[onset_sort_idx]
+
+    if include_grace_notes:
+        # Compute local grace order for each group of grace notes with the same onset time and voice. Modify the note array in place
+        unique_onsets = np.unique(note_array[onset_unit])
+        for onset in unique_onsets:
+            onset_array = note_array[note_array[onset_unit] == onset]
+            grace_onset_array = onset_array[onset_array["is_grace"] == 1]
+            if len(grace_onset_array) > 0:
+                unique_voices = np.unique(grace_onset_array["voice"])
+                for voice in unique_voices:
+                    voice_grace_onset_array = grace_onset_array[grace_onset_array["voice"] == voice]
+                    min_doc_order = voice_grace_onset_array["doc_order"].min()
+                    unique_nids = np.unique(voice_grace_onset_array["id"])
+                    local_order_val = 0
+                    chord_flag = False
+                    for nid in unique_nids:
+                        row_idx = np.where((note_array["id"] == nid))[0]
+                        if note_array[row_idx]["is_grace_chord"] == True:
+                            chord_flag = True
+                        else:
+                            chord_flag = False
+                        note_array["local_grace_order"][row_idx] = local_order_val
+                        if chord_flag:
+                            continue
+                        else:
+                            local_order_val += 1
+            
+
+        note_array = np.lib.recfunctions.drop_fields(note_array, "is_grace_chord")
+        note_array = np.lib.recfunctions.drop_fields(note_array, "doc_order")
 
     return note_array
 

--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -3805,14 +3805,18 @@ def expand_grace_notes_from_local_grace_order(
     return score_note_array
 
 
-def remove_double_notes_from_score(
-    score_part: Any,
+def remove_double_notes_from_score_note_array(
+    score_note_array: np.ndarray,
     choose_longer_note: bool = False,
 ) -> np.ndarray:
     '''
     Remove double notes from the score note array. Double notes are defined as notes that have the same onset time and pitch.
     Such notes are usually meant for visually indicating an overarching melody within a group of voices/notes.
     These double notes need to be removed for various applications such as alignment of score and performance/rehearsal.
+    
+    IMPORTANT! The score note array must be generated with the 'include_grace_notes' parameter set to True 
+    in order for the double notes to be correctly identified and removed, 
+    since some of the double notes can be grace notes.
     
     Parameters
     ----------
@@ -3827,9 +3831,11 @@ def remove_double_notes_from_score(
     score_note_array_no_double: np.ndarray
         A note array of the score with the double notes removed.
     '''
+
+    if 'is_grace' not in score_note_array.dtype.names:
+        raise ValueError("The score_note_array must have the 'is_grace' column in order to remove double notes correctly.")
     
     # get the unique onsets in the score_note_array
-    score_note_array = score_part.note_array(include_grace_notes=True)
     unique_onsets = np.unique(score_note_array['onset_beat'])
     score_note_array_no_double = score_note_array.copy()
     for onset in unique_onsets:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -283,3 +283,12 @@ MUSICXML_CHORD_FEATURES = [
 MXL_TESTFILES = [
     os.path.join(MXL_PATH, fn) for fn in ["mozart_k265_6.mxl"]
 ]
+
+GRACE_NOTE_DOC_ORDER_TESTFILES = [
+    os.path.join(MUSICXML_PATH, fn) 
+    for fn in [
+        "test_acciaccatura_non_chord.musicxml", 
+        "test_acciaccatura_chord.musicxml", 
+        "test_acciaccatura_mixed_chord.musicxml"
+        ]
+]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -292,3 +292,5 @@ GRACE_NOTE_DOC_ORDER_TESTFILES = [
         "test_acciaccatura_mixed_chord.musicxml"
         ]
 ]
+
+DOUBLE_NOTE_TESTFILE = os.path.join(MUSICXML_PATH, "test_double_notes.musicxml")

--- a/tests/data/musicxml/test_acciaccatura_chord.musicxml
+++ b/tests/data/musicxml/test_acciaccatura_chord.musicxml
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Untitled score</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>MuseScore 4.5.0</software>
+      <encoding-date>2026-03-26</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1596.77</page-height>
+      <page-width>1233.87</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="616.935484" default-y="1511.049022" justify="center" valign="top" font-size="22">Acciaccatura Chord</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>subtitle</credit-type>
+    <credit-words default-x="616.935484" default-y="1453.898908" justify="center" valign="top" font-size="14">Test musicxml</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>composer</credit-type>
+    <credit-words default-x="1148.145796" default-y="1411.049022" justify="right" valign="bottom">CP Partitura</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="85.725171" default-y="1511.049022" justify="left" valign="top" font-size="14">Piano</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="206.09">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>0</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note id="n1" default-x="122.54" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note id="n2" default-x="77.97" default-y="-140">
+        <grace slash="yes"/>
+        <pitch>
+          <step>A</step>
+          <octave>2</octave>
+          </pitch>
+        <tie type="start"/>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <notations>
+          <tied type="start"/>
+          </notations>
+        </note>
+      <note id="n3" default-x="77.97" default-y="-130">
+        <grace slash="yes"/>
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <tie type="start"/>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <notations>
+          <tied type="start"/>
+          </notations>
+        </note>
+      <note id="n4" default-x="77.97" default-y="-120">
+        <grace slash="yes"/>
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+          </pitch>
+        <tie type="start"/>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <notations>
+          <tied type="start"/>
+          </notations>
+        </note>
+      <note id="n5" default-x="77.97" default-y="-105">
+        <grace slash="yes"/>
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <tie type="start"/>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <notations>
+          <tied type="start"/>
+          </notations>
+        </note>
+      <note id="n6" default-x="100.63" default-y="-140">
+        <pitch>
+          <step>A</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="stop"/>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <tied type="stop"/>
+          </notations>
+        </note>
+      <note id="n7" default-x="100.63" default-y="-130">
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="stop"/>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <tied type="stop"/>
+          </notations>
+        </note>
+      <note id="n8" default-x="100.63" default-y="-120">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="stop"/>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <tied type="stop"/>
+          </notations>
+        </note>
+      <note id="n9" default-x="100.63" default-y="-105">
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <tie type="stop"/>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <notations>
+          <tied type="stop"/>
+          </notations>
+        </note>
+      <note id="n10" default-x="127.62" default-y="-125">
+        <rest/>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+        </note>
+      <note id="n11" default-x="154.61" default-y="-125">
+        <rest/>
+        <duration>2</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/tests/data/musicxml/test_acciaccatura_mixed_chord.musicxml
+++ b/tests/data/musicxml/test_acciaccatura_mixed_chord.musicxml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Untitled score</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>MuseScore 4.5.0</software>
+      <encoding-date>2026-03-26</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1596.77</page-height>
+      <page-width>1233.87</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="616.935484" default-y="1511.049022" justify="center" valign="top" font-size="22">Acciaccatura Mixed Chord</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>subtitle</credit-type>
+    <credit-words default-x="616.935484" default-y="1453.898908" justify="center" valign="top" font-size="14">Test musicxml</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>composer</credit-type>
+    <credit-words default-x="1148.145796" default-y="1411.049022" justify="right" valign="bottom">CP Partitura</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="85.725171" default-y="1511.049022" justify="left" valign="top" font-size="14">Piano</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="237.55">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>0</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note id="n1" default-x="138.27" default-y="-10">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note id="n2" default-x="77.97" default-y="-120">
+        <grace slash="yes"/>
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+          </pitch>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">begin</beam>
+        </note>
+      <note id="n3" default-x="90.57" default-y="-115">
+        <grace slash="yes"/>
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+          </pitch>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">continue</beam>
+        </note>
+      <note id="n4" default-x="103.17" default-y="-130">
+        <grace slash="yes"/>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">continue</beam>
+        </note>
+      <note id="n5" default-x="115.76" default-y="-140">
+        <grace slash="yes"/>
+        <pitch>
+          <step>A</step>
+          <octave>2</octave>
+          </pitch>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">end</beam>
+        </note>
+      <note id="n6" default-x="115.76" default-y="-130">
+        <grace slash="yes"/>
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        </note>
+      <note id="n7" default-x="115.76" default-y="-120">
+        <grace slash="yes"/>
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+          </pitch>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        </note>
+      <note id="n8" default-x="115.76" default-y="-105">
+        <grace slash="yes"/>
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <voice>5</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        </note>
+      <note id="n9" default-x="132.08" default-y="-140">
+        <pitch>
+          <step>A</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
+      <note id="n10" default-x="132.08" default-y="-130">
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
+      <note id="n11" default-x="132.08" default-y="-120">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
+      <note id="n12" default-x="132.08" default-y="-105">
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        </note>
+      <note id="n13" default-x="159.07" default-y="-125">
+        <rest/>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+        </note>
+      <note id="n14" default-x="186.06" default-y="-125">
+        <rest/>
+        <duration>2</duration>
+        <voice>5</voice>
+        <type>half</type>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/tests/data/musicxml/test_acciaccatura_non_chord.musicxml
+++ b/tests/data/musicxml/test_acciaccatura_non_chord.musicxml
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Untitled score</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>MuseScore 4.5.0</software>
+      <encoding-date>2026-03-26</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1596.77</page-height>
+      <page-width>1233.87</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="616.935484" default-y="1511.049022" justify="center" valign="top" font-size="22">Acciaccatura Non Chord</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>subtitle</credit-type>
+    <credit-words default-x="616.935484" default-y="1453.898908" justify="center" valign="top" font-size="14">Test musicxml</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>composer</credit-type>
+    <credit-words default-x="1148.145796" default-y="1411.049022" justify="right" valign="bottom">CP Partitura</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="85.725171" default-y="1511.049022" justify="left" valign="top" font-size="14">Piano</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="1012.42">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>0</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <direction placement="below">
+        <direction-type>
+          <dynamics default-x="5.32" default-y="-57.06" relative-y="-20">
+            <mf/>
+            </dynamics>
+          </direction-type>
+        <staff>1</staff>
+        <sound dynamics="88.89"/>
+        </direction>
+      <note id="n1" default-x="87.23" default-y="-55">
+        <grace slash="yes"/>
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <voice>1</voice>
+        <type>eighth</type>
+        <accidental>flat</accidental>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        </note>
+      <note id="n2" default-x="106.21" default-y="-40">
+        <grace slash="yes"/>
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <voice>1</voice>
+        <type>eighth</type>
+        <accidental>flat</accidental>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        </note>
+      <note id="n3" default-x="118.8" default-y="-30">
+        <grace slash="yes"/>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        </note>
+      <note id="n4" default-x="137.78" default-y="-20">
+        <grace slash="yes"/>
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <voice>1</voice>
+        <type>eighth</type>
+        <accidental>flat</accidental>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        </note>
+      <note id="n5" default-x="156.76" default-y="-5">
+        <grace slash="yes"/>
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <voice>1</voice>
+        <type>eighth</type>
+        <accidental>flat</accidental>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">end</beam>
+        </note>
+      <note id="n6" default-x="180.25" default-y="15">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <accidental>flat</accidental>
+        <stem>down</stem>
+        <staff>1</staff>
+        </note>
+      <note id="n7" default-x="590.83" default-y="-20">
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note id="n8" default-x="525.7" default-y="-115">
+        <rest measure="yes"/>
+        <duration>4</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/tests/data/musicxml/test_double_notes.musicxml
+++ b/tests/data/musicxml/test_double_notes.musicxml
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Untitled score</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer / arranger</creator>
+    <encoding>
+      <software>MuseScore 4.5.0</software>
+      <encoding-date>2026-04-02</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.99911</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1596.77</page-height>
+      <page-width>1233.87</page-width>
+      <page-margins type="even">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>85.7252</left-margin>
+        <right-margin>85.7252</right-margin>
+        <top-margin>85.7252</top-margin>
+        <bottom-margin>85.7252</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <appearance>
+      <line-width type="light barline">1.8</line-width>
+      <line-width type="heavy barline">5.5</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="bracket">4.5</line-width>
+      <line-width type="dashes">1</line-width>
+      <line-width type="enclosure">1</line-width>
+      <line-width type="ending">1.1</line-width>
+      <line-width type="extend">1</line-width>
+      <line-width type="leger">1.6</line-width>
+      <line-width type="pedal">1.1</line-width>
+      <line-width type="octave shift">1.1</line-width>
+      <line-width type="slur middle">2.1</line-width>
+      <line-width type="slur tip">0.5</line-width>
+      <line-width type="staff">1.1</line-width>
+      <line-width type="stem">1</line-width>
+      <line-width type="tie middle">2.1</line-width>
+      <line-width type="tie tip">0.5</line-width>
+      <line-width type="tuplet bracket">1</line-width>
+      <line-width type="wedge">1.2</line-width>
+      <note-size type="cue">70</note-size>
+      <note-size type="grace">70</note-size>
+      <note-size type="grace-cue">49</note-size>
+      </appearance>
+    <music-font font-family="Leland"/>
+    <word-font font-family="Edwin" font-size="10"/>
+    <lyric-font font-family="Edwin" font-size="10"/>
+    </defaults>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="616.935484" default-y="1511.049022" justify="center" valign="top" font-size="22">Test Double Notes</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>subtitle</credit-type>
+    <credit-words default-x="616.935484" default-y="1453.898908" justify="center" valign="top" font-size="14">(Notes with same onset and pitch)</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-type>composer</credit-type>
+    <credit-words default-x="1148.145796" default-y="1411.049022" justify="right" valign="bottom">CP Partitura</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="85.725171" default-y="1511.049022" justify="left" valign="top" font-size="14">Piano</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="1012.42">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>50</left-margin>
+            <right-margin>0</right-margin>
+            </system-margins>
+          <top-system-distance>170</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>72.5</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>4</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note id="n1" default-x="96.97" default-y="-30">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <dot default-x="114.96" default-y="-25"/>
+        <stem>up</stem>
+        <staff>1</staff>
+        </note>
+      <note id="n2" default-x="419.9" default-y="-20">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <accidental>flat</accidental>
+        <stem>up</stem>
+        <staff>1</staff>
+        </note>
+      <note id="n3" default-x="550.19" default-y="-25">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <dot default-x="568.19" default-y="-25"/>
+        <stem>up</stem>
+        <staff>1</staff>
+        </note>
+      <note id="n4" default-x="885.12" default-y="-35">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <accidental cautionary="yes" parentheses="no">natural</accidental>
+        <stem>up</stem>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>16</duration>
+        </backup>
+      <note id="n5" default-x="82.98" default-y="-30">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <note id="n6" default-x="141.13" default-y="-45">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note id="n7" default-x="187.29" default-y="-102.5">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note id="n8" default-x="245.44" default-y="-112.5">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        </note>
+      <note id="n9" default-x="303.59" default-y="-117.5">
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <note id="n10" default-x="361.74" default-y="-97.5">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note id="n11" default-x="419.9" default-y="-20">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note id="n12" default-x="478.05" default-y="-45">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        </note>
+      <note id="n13" default-x="536.2" default-y="-25">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <note id="n14" default-x="594.35" default-y="-50">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <accidental>sharp</accidental>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note id="n15" default-x="652.51" default-y="-60">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note id="n16" default-x="710.66" default-y="-40">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        </note>
+      <note id="n17" default-x="768.81" default-y="-45">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <note id="n18" default-x="826.96" default-y="-60">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note id="n19" default-x="885.12" default-y="-127.5">
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note id="n20" default-x="943.27" default-y="-112.5">
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>2</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        </note>
+      <backup>
+        <duration>16</duration>
+        </backup>
+      <note id="n21" default-x="525.7" default-y="-122.5" print-object="no">
+        <rest measure="yes"/>
+        <duration>16</duration>
+        <voice>5</voice>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/tests/test_note_array.py
+++ b/tests/test_note_array.py
@@ -9,11 +9,11 @@ import unittest
 
 import partitura.score as score
 from partitura import load_musicxml, load_kern, load_score
-from partitura.utils.music import note_array_from_part, ensure_notearray
+from partitura.utils.music import note_array_from_part, ensure_notearray, expand_grace_notes_from_local_grace_order, remove_double_notes_from_score
 from partitura.musicanalysis import note_array_to_score
 import numpy as np
 
-from tests import NOTE_ARRAY_TESTFILES, KERN_TESTFILES, METRICAL_POSITION_TESTFILES, GRACE_NOTE_DOC_ORDER_TESTFILES
+from tests import NOTE_ARRAY_TESTFILES, KERN_TESTFILES, METRICAL_POSITION_TESTFILES, GRACE_NOTE_DOC_ORDER_TESTFILES, DOUBLE_NOTE_TESTFILE
 
 
 class TestNoteArray(unittest.TestCase):
@@ -263,7 +263,100 @@ class TestNoteArray(unittest.TestCase):
 
                 # check that all the local_grace_order values are the same
                 self.assertTrue(np.all(local_grace_order_values == local_grace_order_values[0]))
+
+    def test_expand_grace_notes_from_local_grace_order(self):
+        """
+        Test that the expand_grace_notes_from_local_grace_order function correctly expands the grace notes in the note array based on their local grace order.
+        """
+        
+        for fn in GRACE_NOTE_DOC_ORDER_TESTFILES:
+            score_part = load_musicxml(fn)[0]
+            expanded_note_array = expand_grace_notes_from_local_grace_order(score_part, grace_offset_quarter=0.25)
+
+            if 'non_chord' in fn:
+                # check that the grace notes are expanded by 0.25 quarter notes before the main note
+                main_note_onset = expanded_note_array[expanded_note_array["is_grace"] == 0]["onset_beat"][0]
+                grace_note_onsets = expanded_note_array[expanded_note_array["is_grace"] == 1]["onset_beat"]
+                grace_note_durations = expanded_note_array[expanded_note_array["is_grace"] == 1]["duration_beat"]
+                grace_notes_length = len(grace_note_onsets)
+
+                self.assertTrue(grace_note_onsets[0] == main_note_onset - 0.25)
+                self.assertTrue(np.all(grace_note_durations == 0.25/grace_notes_length))
+
+                # convert all the grace note onsets to .2f values
+                grace_note_onsets_rounded = np.round(grace_note_onsets, 2)
+                true_onsets = []
+                for i in range(grace_notes_length):
+                    true_onsets.append(np.round(main_note_onset - 0.25 + i*(0.25/grace_notes_length), 2))
+
+                # check that all the values of grace_note_onsets_rounded are equal to the corresponding values in true_onsets
+                self.assertTrue(np.allclose(grace_note_onsets_rounded, true_onsets))
+
+            elif 'mixed_chord' in fn:
+                main_note_onset = expanded_note_array[expanded_note_array["is_grace"] == 0]["onset_beat"][0]
+                grace_note_onsets = expanded_note_array[expanded_note_array["is_grace"] == 1]["onset_beat"]
+                unique_grace_note_onsets = set(grace_note_onsets)
                 
+                # check that the unique grace onsets are not equal to all the grace note onsets, as there is a chordal grace note
+                self.assertTrue(len(unique_grace_note_onsets) == 4)
+                self.assertTrue(len(grace_note_onsets) == 7)
+                
+                grace_note_durations = expanded_note_array[expanded_note_array["is_grace"] == 1]["duration_beat"]
+                grace_notes_length = len(grace_note_onsets)
+                unique_grace_notes_length = len(unique_grace_note_onsets)
+
+                # check that the durations of the grace notes with the same onset are equal, 
+                # and that they are equal to 0.25 divided by the number of unique grace note onsets
+                self.assertTrue(np.all(grace_note_durations == 0.25/unique_grace_notes_length))
+
+                # validate first grace note onset
+                self.assertTrue(grace_note_onsets[0] == main_note_onset - 0.25)
+
+                true_onsets = np.array([-0.25, -0.1875, -0.125, -0.0625, -0.0625, -0.0625, -0.0625])
+
+                self.assertTrue(np.allclose(grace_note_onsets, true_onsets))
+
+
+    def test_remove_double_notes_from_score(self):
+        """
+        Test that the remove_double_notes_from_score function correctly removes double notes from the score.
+        """
+        score_part = load_musicxml(DOUBLE_NOTE_TESTFILE)[0]
+        sna = score_part.note_array()
+
+        for i in range(2):
+            if i == 0:
+                sna_no_double = remove_double_notes_from_score(score_part)
+            else:
+                sna_no_double = remove_double_notes_from_score(score_part, choose_longer_note=True)
+            
+            # check that the number of notes in sna_no_double is less than the number of notes in sna
+            self.assertTrue(len(sna) - len(sna_no_double) == 3)
+
+            sna_ids = set(sna["id"])
+            sna_no_double_ids = set(sna_no_double["id"])
+            sna_double_only_ids = sna_ids - sna_no_double_ids
+            sna_double_only = sna[np.isin(sna["id"], list(sna_double_only_ids))]
+            
+            # test the 'choose_longer_note' functionality
+            for note in sna_double_only:
+                onset = note["onset_beat"]
+                pitch = note["pitch"]
+                duration = note["duration_beat"]
+
+                corresponding_notes = sna[(sna["onset_beat"] == onset) & (sna["pitch"] == pitch) & (sna["id"] != note["id"])]
+
+                self.assertTrue(len(corresponding_notes) == 1)
+                if i == 0:    
+                    self.assertTrue(duration > corresponding_notes["duration_beat"][0])
+                else:
+                    self.assertTrue(duration < corresponding_notes["duration_beat"][0])
+    
+
+
+
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_note_array.py
+++ b/tests/test_note_array.py
@@ -13,7 +13,7 @@ from partitura.utils.music import note_array_from_part, ensure_notearray
 from partitura.musicanalysis import note_array_to_score
 import numpy as np
 
-from tests import NOTE_ARRAY_TESTFILES, KERN_TESTFILES, METRICAL_POSITION_TESTFILES
+from tests import NOTE_ARRAY_TESTFILES, KERN_TESTFILES, METRICAL_POSITION_TESTFILES, GRACE_NOTE_DOC_ORDER_TESTFILES
 
 
 class TestNoteArray(unittest.TestCase):
@@ -229,6 +229,41 @@ class TestNoteArray(unittest.TestCase):
                 # field.
                 self.assertTrue(field_name in na.dtype.names)
 
+    def test_gracenote_doc_order(self):
+        """
+        Test that the document order of grace notes is correctly reflected in the note array.
+        """
+        for fn in GRACE_NOTE_DOC_ORDER_TESTFILES:
+            score_part = load_musicxml(fn)[0]
+            sna = score_part.note_array(include_grace_notes=True)
+
+            expected_field_names = [
+                "is_grace",
+                "grace_type",
+                "steal_proportion",
+                "local_grace_order",
+            ]
+            
+            for field_name in expected_field_names:
+                self.assertTrue(field_name in sna.dtype.names)
+            
+            grace_notes_array = sna[sna["is_grace"] == 1]
+            local_grace_order_values = grace_notes_array["local_grace_order"]
+
+            if 'non_chord' in fn:
+                # check that all the local_grace_order_values are unique
+                self.assertTrue(len(local_grace_order_values)==len(set(local_grace_order_values)))
+            
+            elif 'mixed_chord' in fn:
+                # check that the set of local_grace_order_values is equal to 4
+                self.assertTrue(len(local_grace_order_values) == 7)
+                self.assertTrue(set(local_grace_order_values) == set([0,1,2,3]))
+            
+            else:
+
+                # check that all the local_grace_order values are the same
+                self.assertTrue(np.all(local_grace_order_values == local_grace_order_values[0]))
+                
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_note_array.py
+++ b/tests/test_note_array.py
@@ -9,7 +9,7 @@ import unittest
 
 import partitura.score as score
 from partitura import load_musicxml, load_kern, load_score
-from partitura.utils.music import note_array_from_part, ensure_notearray, expand_grace_notes_from_local_grace_order, remove_double_notes_from_score
+from partitura.utils.music import note_array_from_part, ensure_notearray, expand_grace_notes_from_local_grace_order, remove_double_notes_from_score_note_array
 from partitura.musicanalysis import note_array_to_score
 import numpy as np
 
@@ -322,13 +322,13 @@ class TestNoteArray(unittest.TestCase):
         Test that the remove_double_notes_from_score function correctly removes double notes from the score.
         """
         score_part = load_musicxml(DOUBLE_NOTE_TESTFILE)[0]
-        sna = score_part.note_array()
+        sna = score_part.note_array(include_grace_notes=True)
 
         for i in range(2):
             if i == 0:
-                sna_no_double = remove_double_notes_from_score(score_part)
+                sna_no_double = remove_double_notes_from_score_note_array(sna)
             else:
-                sna_no_double = remove_double_notes_from_score(score_part, choose_longer_note=True)
+                sna_no_double = remove_double_notes_from_score_note_array(sna, choose_longer_note=True)
             
             # check that the number of notes in sna_no_double is less than the number of notes in sna
             self.assertTrue(len(sna) - len(sna_no_double) == 3)

--- a/tests/test_note_array.py
+++ b/tests/test_note_array.py
@@ -271,17 +271,20 @@ class TestNoteArray(unittest.TestCase):
         
         for fn in GRACE_NOTE_DOC_ORDER_TESTFILES:
             score_part = load_musicxml(fn)[0]
+            sna = score_part.note_array(include_grace_notes=True)
             expanded_note_array = expand_grace_notes_from_local_grace_order(score_part, grace_offset_quarter=0.25)
 
             if 'non_chord' in fn:
                 # check that the grace notes are expanded by 0.25 quarter notes before the main note
                 main_note_onset = expanded_note_array[expanded_note_array["is_grace"] == 0]["onset_beat"][0]
                 grace_note_onsets = expanded_note_array[expanded_note_array["is_grace"] == 1]["onset_beat"]
-                grace_note_durations = expanded_note_array[expanded_note_array["is_grace"] == 1]["duration_beat"]
                 grace_notes_length = len(grace_note_onsets)
 
                 self.assertTrue(grace_note_onsets[0] == main_note_onset - 0.25)
-                self.assertTrue(np.all(grace_note_durations == 0.25/grace_notes_length))
+
+                grace_notes_expanded = expanded_note_array[expanded_note_array["is_grace"] == 1]
+                grace_notes_original = sna[sna["is_grace"] == 1]
+                self.assertTrue(np.allclose(grace_notes_expanded["duration_beat"], grace_notes_original["duration_beat"] + 0.05))
 
                 # convert all the grace note onsets to .2f values
                 grace_note_onsets_rounded = np.round(grace_note_onsets, 2)
@@ -301,13 +304,12 @@ class TestNoteArray(unittest.TestCase):
                 self.assertTrue(len(unique_grace_note_onsets) == 4)
                 self.assertTrue(len(grace_note_onsets) == 7)
                 
-                grace_note_durations = expanded_note_array[expanded_note_array["is_grace"] == 1]["duration_beat"]
                 grace_notes_length = len(grace_note_onsets)
-                unique_grace_notes_length = len(unique_grace_note_onsets)
-
-                # check that the durations of the grace notes with the same onset are equal, 
-                # and that they are equal to 0.25 divided by the number of unique grace note onsets
-                self.assertTrue(np.all(grace_note_durations == 0.25/unique_grace_notes_length))
+                
+                grace_notes_expanded = expanded_note_array[expanded_note_array["is_grace"] == 1]
+                grace_notes_original = sna[sna["is_grace"] == 1]
+                for i in range(len(grace_notes_expanded)):
+                    self.assertTrue(grace_notes_expanded["duration_beat"][i] == grace_notes_original["duration_beat"][i] + 0.0625)
 
                 # validate first grace note onset
                 self.assertTrue(grace_note_onsets[0] == main_note_onset - 0.25)
@@ -315,6 +317,13 @@ class TestNoteArray(unittest.TestCase):
                 true_onsets = np.array([-0.25, -0.1875, -0.125, -0.0625, -0.0625, -0.0625, -0.0625])
 
                 self.assertTrue(np.allclose(grace_note_onsets, true_onsets))
+
+            else:
+                # check that the grace notes in expanded_note_array have a duration of 0.25 more than the corresponding grace notes in sna
+                grace_notes_expanded = expanded_note_array[expanded_note_array["is_grace"] == 1]
+                grace_notes_original = sna[sna["is_grace"] == 1]
+                for i in range(len(grace_notes_expanded)):
+                    self.assertTrue(grace_notes_expanded["duration_beat"][i] == grace_notes_original["duration_beat"][i] + 0.25)
 
 
     def test_remove_double_notes_from_score(self):


### PR DESCRIPTION
There are situations in certain scores such as Rachmaninoff's Piano Concerto No. 3, Movement 1, where we notice multiple grace notes being associated with a specific beat in the score. 
On some occasions, these grace notes have an intended sequential order within them, as seen in the image below:

**Fig. 1:**
<img width="297" height="207" alt="Acciaccatura_non_chord" src="https://github.com/user-attachments/assets/cd8f2f57-e149-4cd9-bb74-728a227fc987" />

On other occasions, the grace notes are intended to be played together as a chord, as seen in the following image:

**Fig. 2:**
<img width="275" height="147" alt="Acciacatura_chord" src="https://github.com/user-attachments/assets/dd74563c-3b54-4eef-b498-489c9b41159d" />

While this information is provided in the MusicXML score in terms of the document order in which these grace note elements appear, it is currently not passed on to the score note array.

The enhancement associated with this pull request allows for this information to be passed on to the score note array by creating a new field in the array titled 'local_grace_order' when the 'include_grace_notes' flag is True while creating a note array from a score part.
For a given onset unit and a given voice, all the respective grace notes are assigned integers values from 0 upwards according to their document order, while all non-grace notes are assigned the value -1. The grace notes in **Fig. 3** below will therefore be assigned the 'local_grace_order' values 0, 1, 2, 3 and 4 respectively.

**Fig. 3:**

<img width="183" height="134" alt="non_chord_example" src="https://github.com/user-attachments/assets/c0b5fbcf-1152-4146-b6b7-ef5f95427cd8" />


If such grace notes contain the <chord/> tag within the MusicXML document, all such grace notes are given the same 'local_grace_order' value, as they are intended to play together. All the grace notes in **Fig. 2** will be assigned the 'local_grace_order' value of 0.

In the case of situations where there is a mix of sequential and chordal grace notes, such as in this image:

**Fig. 4:**
<img width="180" height="125" alt="Acciaccatura_mixed_chord" src="https://github.com/user-attachments/assets/dafecc0f-c345-4fe1-b213-86c737daf9b8" />

the first three grace notes are assigned the 'local_grace_order' values 0, 1 and 2 respectively, and the chord of four grace notes are all assigned the value 3.