### PR TITLE
Score directions maps

### DIFF
--- a/partitura/directions.py
+++ b/partitura/directions.py
@@ -516,7 +516,9 @@ def parse_direction(string):
 
     """
     global DEFAULT_PARSER
+
     if DEFAULT_PARSER:
+        string = string.strip().rstrip(".") # remove trailing punctuation
         try:
             parse_result = DEFAULT_PARSER.parse(string)
             direction = create_directions(parse_result, string)

--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -974,6 +974,9 @@ def _handle_direction(e, position, part, ongoing):
             # words items, so we loop:
             for child in direction_type:
                 # try to make a direction out of words
+                if child.text is None: 
+                    continue
+
                 parse_result = parse_direction(child.text)
                 starting_directions.extend(parse_result)
 

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -799,9 +799,10 @@ class Part(object):
 
     @property
     def tempo_directions_map(self):
-        """A function mapping timeline times to the ConstantTempoDirection
-        active at that time. The function can take scalar values or 
-        lists/arrays of values.
+        """A function mapping timeline times to the TempoDirection
+        active at that time. Returns None for times before the first direction,
+        and fills forward after the last direction.
+        The function can take scalar values or lists/arrays of values.
         
         Returns
         -------
@@ -814,67 +815,34 @@ class Part(object):
             warnings.warn("No tempo directions found, returning None map")
             return lambda t: np.full(np.asarray(t).shape, None) if np.ndim(t) > 0 else None
         
-        measure_dur = self.measures[0].duration
-        fallback_dur = 2 * measure_dur
-
-        print(len(td_it), 'tempo directions')
-
+        fallback_dur = 2 * self.measures[0].duration
         directions = np.zeros((len(td_it), 3))
-        for i, td in enumerate(td_it):
-            start = td.start.t
-            if td.end is not None:
-                end = td.end.t
-            elif i + 1 < len(td_it) and td_it[i + 1].start is not None:
-                end = td_it[i + 1].start.t
-            else:
-                end = start + fallback_dur
+        for i, cd in enumerate(td_it):
+            start = cd.start.t
+            end = cd.end.t if cd.end is not None else (
+                td_it[i + 1].start.t if i + 1 < len(td_it) and td_it[i + 1].start is not None
+                else start + fallback_dur
+            )
             directions[i] = [start, end, i]
-            print(i, td, start, end) # TODOTODOTO
 
         # index-to-object lookup
         idx_to_direction = {i: td for i, td in enumerate(td_it)}
-        print('mapping:', idx_to_direction )
-
-        # inter_function_idx = interp1d(
-        #     directions[:, 0],   # x: start times
-        #     directions[:, 2],   # y: indices
-        #     kind="previous",
-        #     fill_value="extrapolate",
-        #     dtype=int,
-        # )
+        start_times = directions[:, 0]
+        max_idx = len(td_it) - 1
 
         def inter_function(t):
             scalar = np.ndim(t) == 0
             t = np.atleast_1d(np.asarray(t))
-            
-            start_times = directions[:, 0]  # [2, 4, 5]
-            
-            # searchsorted returns the index where t would be inserted
-            # 'right' means: for t==2, returns 1 (i.e. "after" index 0)
-            indices = np.searchsorted(start_times, t, side='right') - 1
-            
-            result = np.empty(len(t), dtype=object)
-            for j, idx in enumerate(indices):
-                if idx < 0:  # before first direction → None
-                    result[j] = None
-                else:        # at or after first direction → fill forward (clamped to last)
-                    result[j] = idx_to_direction[int(np.clip(idx, 0, len(cd_it) - 1))]
-            
-            return result[0] if scalar else result
 
-        # def inter_function(t):
-        #     idx = inter_function_idx(t)
-        #     if np.ndim(idx) == 0:
-        #         i = int(idx)
-        #         return idx_to_direction.get(i, None)
-        #     return np.array([idx_to_direction.get(int(i), None) for i in idx])
-        
-        # def inter_function(t):
-        #     idx = inter_function_idx(t)
-        #     print('idx', idx)
-        #     if np.ndim(idx) == 0:  # scalar
-        #         return idx_to_direction[int(idx)]
-        #     return np.array([idx_to_direction[int(i)] for i in idx])
+            indices = np.searchsorted(start_times, t, side='right') - 1
+            clipped = np.clip(indices, 0, max_idx)
+                
+            result = np.where(
+                indices < 0,
+                None,
+                np.array([idx_to_direction[i] for i in clipped], dtype=object)
+            )
+            return result[0] if scalar else result
 
         return inter_function
 

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -711,19 +711,21 @@ class Part(object):
 
         """
         return [e for e in self.iter_all(LoudnessDirection, include_subclasses=True)]
-
+    
+    
     @property
     def constant_dynamics_map(self):
         """A function mapping timeline times to the ConstantLoudnessDirection
-        active at that time. The function can take scalar values or
-        lists/arrays of values.
+        active at that time. Returns None for times before the first direction,
+        and fills forward after the last direction.
+        The function can take scalar values or lists/arrays of values.
         Returns
         -------
         function
             The mapping function
         """
         cd_it = [e for e in self.dynamics if isinstance(e, ConstantLoudnessDirection)]
-        
+
         if len(cd_it) == 0:
             warnings.warn("No constant dynamics found, returning None map")
             return lambda t: np.full(np.asarray(t).shape, None) if np.ndim(t) > 0 else None
@@ -739,20 +741,22 @@ class Part(object):
             directions[i] = [start, end, i]
 
         idx_to_direction = {i: cd for i, cd in enumerate(cd_it)}
-
-        inter_function_idx = interp1d(
-            directions[:, 0],
-            directions[:, 2],
-            kind="previous",
-            fill_value="extrapolate",
-            dtype=int,
-        )
+        start_times = directions[:, 0]
+        max_idx = len(cd_it) - 1
 
         def inter_function(t):
-            idx = inter_function_idx(t)
-            if np.ndim(idx) == 0:
-                return idx_to_direction[int(idx)]
-            return np.array([idx_to_direction[int(i)] for i in idx])
+            scalar = np.ndim(t) == 0
+            t = np.atleast_1d(np.asarray(t))
+
+            indices = np.searchsorted(start_times, t, side='right') - 1
+            clipped = np.clip(indices, 0, max_idx)
+                
+            result = np.where(
+                indices < 0,
+                None,
+                np.array([idx_to_direction[i] for i in clipped], dtype=object)
+            )
+            return result[0] if scalar else result
 
         return inter_function
     
@@ -813,6 +817,8 @@ class Part(object):
         measure_dur = self.measures[0].duration
         fallback_dur = 2 * measure_dur
 
+        print(len(td_it), 'tempo directions')
+
         directions = np.zeros((len(td_it), 3))
         for i, td in enumerate(td_it):
             start = td.start.t
@@ -823,23 +829,52 @@ class Part(object):
             else:
                 end = start + fallback_dur
             directions[i] = [start, end, i]
+            print(i, td, start, end) # TODOTODOTO
 
-        # index-to-object lookup — unchanged
+        # index-to-object lookup
         idx_to_direction = {i: td for i, td in enumerate(td_it)}
+        print('mapping:', idx_to_direction )
 
-        inter_function_idx = interp1d(
-            directions[:, 0],   # x: start times
-            directions[:, 2],   # y: indices
-            kind="previous",
-            fill_value="extrapolate",
-            dtype=int,
-        )
+        # inter_function_idx = interp1d(
+        #     directions[:, 0],   # x: start times
+        #     directions[:, 2],   # y: indices
+        #     kind="previous",
+        #     fill_value="extrapolate",
+        #     dtype=int,
+        # )
 
         def inter_function(t):
-            idx = inter_function_idx(t)
-            if np.ndim(idx) == 0:  # scalar
-                return idx_to_direction[int(idx)]
-            return np.array([idx_to_direction[int(i)] for i in idx])
+            scalar = np.ndim(t) == 0
+            t = np.atleast_1d(np.asarray(t))
+            
+            start_times = directions[:, 0]  # [2, 4, 5]
+            
+            # searchsorted returns the index where t would be inserted
+            # 'right' means: for t==2, returns 1 (i.e. "after" index 0)
+            indices = np.searchsorted(start_times, t, side='right') - 1
+            
+            result = np.empty(len(t), dtype=object)
+            for j, idx in enumerate(indices):
+                if idx < 0:  # before first direction → None
+                    result[j] = None
+                else:        # at or after first direction → fill forward (clamped to last)
+                    result[j] = idx_to_direction[int(np.clip(idx, 0, len(cd_it) - 1))]
+            
+            return result[0] if scalar else result
+
+        # def inter_function(t):
+        #     idx = inter_function_idx(t)
+        #     if np.ndim(idx) == 0:
+        #         i = int(idx)
+        #         return idx_to_direction.get(i, None)
+        #     return np.array([idx_to_direction.get(int(i), None) for i in idx])
+        
+        # def inter_function(t):
+        #     idx = inter_function_idx(t)
+        #     print('idx', idx)
+        #     if np.ndim(idx) == 0:  # scalar
+        #         return idx_to_direction[int(idx)]
+        #     return np.array([idx_to_direction[int(i)] for i in idx])
 
         return inter_function
 

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -713,6 +713,75 @@ class Part(object):
         return [e for e in self.iter_all(LoudnessDirection, include_subclasses=True)]
 
     @property
+    def constant_dynamics_map(self):
+        """A function mapping timeline times to the ConstantLoudnessDirection
+        active at that time. The function can take scalar values or
+        lists/arrays of values.
+        Returns
+        -------
+        function
+            The mapping function
+        """
+        cd_it = [e for e in self.dynamics if isinstance(e, ConstantLoudnessDirection)]
+        
+        if len(cd_it) == 0:
+            warnings.warn("No constant dynamics found, returning None map")
+            return lambda t: np.full(np.asarray(t).shape, None) if np.ndim(t) > 0 else None
+
+        fallback_dur = 2 * self.measures[0].duration
+        directions = np.zeros((len(cd_it), 3))
+        for i, cd in enumerate(cd_it):
+            start = cd.start.t
+            end = cd.end.t if cd.end is not None else (
+                cd_it[i + 1].start.t if i + 1 < len(cd_it) and cd_it[i + 1].start is not None
+                else start + fallback_dur
+            )
+            directions[i] = [start, end, i]
+
+        idx_to_direction = {i: cd for i, cd in enumerate(cd_it)}
+
+        inter_function_idx = interp1d(
+            directions[:, 0],
+            directions[:, 2],
+            kind="previous",
+            fill_value="extrapolate",
+            dtype=int,
+        )
+
+        def inter_function(t):
+            idx = inter_function_idx(t)
+            if np.ndim(idx) == 0:
+                return idx_to_direction[int(idx)]
+            return np.array([idx_to_direction[int(i)] for i in idx])
+
+        return inter_function
+    
+    @property
+    def variable_dynamics_map(self):
+        """A function mapping timeline times to variable Dynamics Markings (i.e., increasing and decreasing ones)
+        at that exact time, or None outside of marked regions.
+        Returns
+        -------
+        function
+            The mapping function
+        """
+        id_it = [e for e in self.dynamics if not isinstance(e, ConstantLoudnessDirection)]
+
+        if len(id_it) == 0:
+            warnings.warn("No impulsive dynamics found, returning None map")
+            return lambda t: np.full(np.asarray(t).shape, None) if np.ndim(t) > 0 else None
+
+        # build a lookup dict: start time -> object
+        time_to_direction = {d.start.t: d for d in id_it if d.start is not None}
+
+        def inter_function(t):
+            if np.ndim(t) == 0:  # scalar
+                return time_to_direction.get(int(t), None)
+            return np.array([time_to_direction.get(int(ti), None) for ti in t])
+
+        return inter_function
+
+    @property
     def tempo_directions(self):
         """Return a list of all tempo direction in the part
 

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -725,6 +725,56 @@ class Part(object):
         return [e for e in self.iter_all(TempoDirection, include_subclasses=True)]
 
     @property
+    def tempo_directions_map(self):
+        """A function mapping timeline times to the ConstantTempoDirection
+        active at that time. The function can take scalar values or 
+        lists/arrays of values.
+        
+        Returns
+        -------
+        function
+            The mapping function
+        """
+        td_it = self.tempo_directions
+        
+        if len(td_it) == 0:
+            warnings.warn("No tempo directions found, returning None map")
+            return lambda t: np.full(np.asarray(t).shape, None) if np.ndim(t) > 0 else None
+        
+        measure_dur = self.measures[0].duration
+        fallback_dur = 2 * measure_dur
+
+        directions = np.zeros((len(td_it), 3))
+        for i, td in enumerate(td_it):
+            start = td.start.t
+            if td.end is not None:
+                end = td.end.t
+            elif i + 1 < len(td_it) and td_it[i + 1].start is not None:
+                end = td_it[i + 1].start.t
+            else:
+                end = start + fallback_dur
+            directions[i] = [start, end, i]
+
+        # index-to-object lookup — unchanged
+        idx_to_direction = {i: td for i, td in enumerate(td_it)}
+
+        inter_function_idx = interp1d(
+            directions[:, 0],   # x: start times
+            directions[:, 2],   # y: indices
+            kind="previous",
+            fill_value="extrapolate",
+            dtype=int,
+        )
+
+        def inter_function(t):
+            idx = inter_function_idx(t)
+            if np.ndim(idx) == 0:  # scalar
+                return idx_to_direction[int(idx)]
+            return np.array([idx_to_direction[int(i)] for i in idx])
+
+        return inter_function
+
+    @property
     def cadences(self):
         """Return a list of all cadences in the part
 

--- a/partitura/score.py
+++ b/partitura/score.py
@@ -719,6 +719,10 @@ class Part(object):
         active at that time. Returns None for times before the first direction,
         and fills forward after the last direction.
         The function can take scalar values or lists/arrays of values.
+        
+        Note: Currently this function does not consider changes in the time signature, and takes as 
+        fallback duration a fixed length of the duration of the first measure in a score.
+
         Returns
         -------
         function


### PR DESCRIPTION
- adds score direction maps for tempo and dynamics directions
- fixes a bug for tempo directions that are abbreviated with a trailing period (e.g., ten. -> tenuto) were not recognized as valid directions