### PR TITLE
look up ref "sameas" element in MEI parser

### DIFF
--- a/partitura/io/importmei.py
+++ b/partitura/io/importmei.py
@@ -597,7 +597,20 @@ class MeiParser(object):
         symbolic_duration :
         """
         # symbolic duration
-        symbolic_duration = self._get_symbolic_duration(el)
+
+        if el.get("sameas") is not None:
+            ref_id = el.get("sameas")
+            ref_id = ref_id.lstrip("#")   
+            root = self.document.getroot()
+            found_element = root.xpath(f"//*[@xml:id='{ref_id}']",
+                                       namespaces={"xml":self.ns})
+            if found_element is not None:
+                symbolic_duration = self._get_symbolic_duration(found_element[0])
+            else:
+                symbolic_duration = 0
+        
+        else:
+            symbolic_duration = self._get_symbolic_duration(el)
 
         # duration in ppq
         if el.get("dur.ppq") is not None or el.get("grace") is not None:


### PR DESCRIPTION
an element may refer to another using the sameas attribute along with an xml:id and inherit some of the other's properties. this change implements a lookup for the case of durations of rests. the pattern should work in general, but I don't know exactly where else we might encounter it.