### PR TITLE
Support non-unique alignments (Virtual Pointers/Sections) & fix measure numbering

### DIFF
--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -473,41 +473,6 @@ def matchfile_from_alignment(
         duplicate_idx = np.hstack(list(duplicates.values()))
         voice_overlap_note_ids = list(sna[duplicate_idx]["id"])
 
-    # TODO: if version > Version(1, 0, 0): sort alignment list according to perf_time before starting the for loop
-    # Note: don't use pnote_sort_info for the sorting as time mapping probably does not make a lot of sense when sections are repeated and there are section jumps
-    # Sort alignment list according to perf_time before starting the loop for newer versions
-    
-    # should we sort the alignment at all? Shouldn't it be the alignment algorithm's job to also define where the deletions happen in the alignment?
-    if version > Version(1, 0, 0):
-        sortable_alignment = []
-        
-        for i, al in enumerate(alignment):
-            pid = al.get("performance_id")
-            
-            if pid and pid in perf_info:
-                # Matches, Insertions, Ornaments: Use exact recorded MIDI ticks
-                onset = perf_info[pid].Onset
-                sort_key = (onset, 0, i)
-            else:
-                # map Score Time to Performance Time
-                sid = al.get("score_id")
-                snote = score_info[sid]
-                
-                # Map Score Beats -> Estimated Performance Seconds
-                est_perf_sec = float(stime_to_ptime_map(snote.OnsetInBeats))
-                # Convert Seconds -> MIDI Ticks
-                onset = seconds_to_midi_ticks(est_perf_sec, mpq=mpq, ppq=ppq)
-                
-                # '1' ensures deletions sort safely after played notes at the exact same tick
-                sort_key = (onset, 1, i)
-                
-            sortable_alignment.append((sort_key, al))
-            
-        # Sort ascending based on the keys
-        sortable_alignment.sort(key=lambda item: item[0])
-        
-        # Unpack back into the standard alignment list
-        alignment = [item[1] for item in sortable_alignment]
 
     aligned_snotes, aligned_pnotes = [], []
 
@@ -637,6 +602,9 @@ def matchfile_from_alignment(
         sort_stime = np.array(sort_stime)
         sort_stime_idx = np.lexsort((sort_stime[:, 1], sort_stime[:, 0]))
         note_lines = np.array(note_lines)[sort_stime_idx]
+    # Note: The alignment list is deliberately left unsorted for version > Version(1,0,0). 
+    # Sorting by performance time or score time destroys the alignment algorithm's original pathing, 
+    # tearing deletions away from their logical context and breaking structural repeats.
 
     # Create match lines for pedal information
     pedal_lines = []

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -82,8 +82,6 @@ def matchfile_from_alignment(
     tempo_indication: Optional[str] = None,
     diff_score_version_notes: Optional[list] = None,
     version: Version = LATEST_VERSION,
-    note_to_min_id: Optional[dict] = None,
-    unified_note_ids: Optional[dict] = None,
     sections: Optional[List[dict]] = [],  # New: list of section dicts
     omitted_sections: Optional[List[dict]] = [],  # New: list of omitted section dicts
     debug: bool = False,
@@ -532,31 +530,6 @@ def matchfile_from_alignment(
                 virtualSnote_virtualnote_line = MatchVirtualSnoteVirtualNote(version=version, snote=virtualSnote, note=virtualnote)
                 note_lines.append(virtualSnote_virtualnote_line)
 
-            if version > Version(1, 0, 0):
-                if al_note["score_id"] in unified_note_ids:
-                    # ALIGN ALL REPEATED SNOTES TO THE VIRTUAL_PNOTE
-                    min_id = note_to_min_id[al_note["score_id"]]
-                    duplicates = unified_note_ids[min_id].copy()
-                    duplicates.remove(al_note["score_id"])
-                    virtualnote = MatchVirtualPNote(
-                                    version=version,
-                                    id=al_note["performance_id"],
-                                )
-                    for sid in duplicates:
-                        if sid not in aligned_snotes:
-                            snote = score_info[sid]
-                            snote_virtualnote_line = MatchSnoteVirtualNote(version=version, snote=snote, note=virtualnote)
-                            note_lines.append(snote_virtualnote_line)
-                            aligned_snotes.append(sid)
-                        else:
-                            virtualSnote = MatchVirtualSnote(
-                                version=version,
-                                anchor=al_note["score_id"],
-                                attributes_list=al_note.get("score_attributes_list", []),
-                            )
-                            virtualSnote_virtualnote_line = MatchVirtualSnoteVirtualNote(version=version, snote=virtualSnote, note=virtualnote)
-                            note_lines.append(virtualSnote_virtualnote_line)
-
         elif label == "deletion":
             skip_deletion = False
             snote = score_info[al_note["score_id"]]
@@ -691,8 +664,6 @@ def save_match(
     performance_filename: Optional[PathLike] = None,
     assume_unfolded: bool = True,
     version: tuple = (LATEST_VERSION.major, LATEST_VERSION.minor, LATEST_VERSION.patch),
-    note_to_min_id: Optional[dict] = None,
-    unified_note_ids: Optional[dict] = None,
     sections: Optional[List[dict]] = [],
     omitted_sections: Optional[List[dict]] = [],
 ) -> Optional[MatchFile]:
@@ -783,8 +754,6 @@ def save_match(
         performance_filename=performance_filename,
         assume_part_unfolded=assume_unfolded,
         version=Version(version[0], version[1], version[2]),
-        note_to_min_id=note_to_min_id,
-        unified_note_ids=unified_note_ids,
         sections=sections,
         omitted_sections=omitted_sections,
     )

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -217,9 +217,32 @@ def matchfile_from_alignment(
     measures = measures[measure_sorting_idx]
 
     start_measure_num = 0 if measure_starts_beats.min() < 0 else 1
+    seq_measure_nums = np.arange(start_measure_num, start_measure_num + len(measure_starts_divs))
+    
+    # parse native measure numbers
+    parsed_nums = []
+    for i, m in enumerate(measures):
+        mnum = seq_measure_nums[i]
+        if getattr(m, "number", None) is not None:
+            try:
+                mnum = int(m.number)
+            except (ValueError, TypeError):
+                pass
+        parsed_nums.append(mnum)
+
+    # global offset based on first measure:
+    # if anacrusis: first measure == 0 -> otherwise, 1_
+    expected_first_num = 0 if measure_starts_beats.min() < 0 else 1
+    
+    if len(parsed_nums) > 0:
+        offset = expected_first_num - parsed_nums[0]
+        actual_measure_nums = [n + offset for n in parsed_nums]
+    else:
+        actual_measure_nums = parsed_nums
+
     measure_starts = np.column_stack(
         (
-            np.arange(start_measure_num, start_measure_num + len(measure_starts_divs)),
+            actual_measure_nums,
             measure_starts_divs,
             measure_starts_beats,
         )
@@ -460,7 +483,6 @@ def matchfile_from_alignment(
 
     aligned_snotes, aligned_pnotes = [], []
     section_lines, omitted_section_lines = [], []
-    #pdb.set_trace()
     current_section_idx = -1
     ###############################
     #sort: # TODO: maybe sort before
@@ -473,7 +495,6 @@ def matchfile_from_alignment(
     #            sort_ptime.append(snote_sort_info[al_note["score_id"]])
         
     ###############################
-    pdb.set_trace()
     # TODO: why doesn't it sort before going through the for-loop?
     for al_note in alignment:
         label = al_note["label"]
@@ -632,8 +653,6 @@ def matchfile_from_alignment(
                 section_attr_list=osec['section_attr_list']
             )
             omitted_section_lines.append(omitted_section_line)
-    #############################################################################
-    #pdb.set_trace()
 
     # sort notes by score onset or by performance onset (for V1.1.0) 
     # (performed insertions are sorted
@@ -648,7 +667,6 @@ def matchfile_from_alignment(
         note_lines = np.array(note_lines)[sort_time_idx]
     
 
-    #pdb.set_trace()
     current_section_idx = -1
     line_idx = 0
     original_note_lines = note_lines.copy()
@@ -676,7 +694,6 @@ def matchfile_from_alignment(
                     current_section_idx += 1
                 line_idx += 1 # we iterated to the next line
     
-    #pdb.set_trace()
     # Create match lines for pedal information
     pedal_lines = []
     for c in ppart.controls:

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -82,7 +82,6 @@ def matchfile_from_alignment(
     tempo_indication: Optional[str] = None,
     diff_score_version_notes: Optional[list] = None,
     version: Version = LATEST_VERSION,
-    use_new_format: bool = False,  # New flag for new format
     note_to_min_id: Optional[dict] = None,
     unified_note_ids: Optional[dict] = None,
     sections: Optional[List[dict]] = [],  # New: list of section dicts
@@ -126,9 +125,7 @@ def matchfile_from_alignment(
     diff_score_version_notes : list or None
         A list of score notes that reflect a special score version (e.g., original edition/Erstdruck, Editors note etc.)
     version: Version
-        Version of the match file. For now only 1.0.0 is supported.
-    use_new_format : bool
-        If True, use the new Match format (Version 2.0.0) with virtual notes and sections.
+        Version of the match file. For now only versions higher or equal to 1.0.0 are supported.
     sections : list of dict or None
         List of sections: each dict with 'id', 'start_beats_unfolded', etc.
     omitted_sections : list of dict or None
@@ -138,11 +135,8 @@ def matchfile_from_alignment(
     matchfile : MatchFile
         An instance of `partitura.io.importmatch.MatchFile`.
     """
-    if use_new_format:
-        version = Version(1, 1, 0)
-    else:
-        if version < Version(1, 0, 0):
-            raise ValueError("Version should >= 1.0.0")
+    if version < Version(1, 0, 0):
+        raise ValueError("Version should >= 1.0.0")
 
     if not assume_part_unfolded:
         # unfold score according to alignment
@@ -201,8 +195,8 @@ def matchfile_from_alignment(
 
     # Measure map (which measure corresponds to which time point in divs)
     beat_map = spart.beat_map
-    
-    ptime_to_stime_map, _ = get_time_maps_from_alignment(#TODO: How much sense does that make for rehearsal?
+
+    ptime_to_stime_map, _ = get_time_maps_from_alignment(
         ppart_or_note_array=ppart.note_array(),
         spart_or_note_array=spart.note_array(),
         alignment=alignment,
@@ -321,7 +315,7 @@ def matchfile_from_alignment(
                         fifths=int(ksig.fifths),
                         mode=ksig.mode,
                         is_list=False,
-                        fmt="v1.0.0",#f"v{version.major}.{version.minor}.{version.patch}",
+                        fmt=f"v{version.major}.{version.minor}.{version.patch}",
                     ),
                     measure=int(mnum),
                     beat=beat + 1,
@@ -464,7 +458,7 @@ def matchfile_from_alignment(
             pnote["midi_pitch"],
         )
 
-    sort_stime, sort_ptime = [], []
+    sort_stime = []
     note_lines = []
 
     # Get ids of notes which voice overlap
@@ -481,24 +475,13 @@ def matchfile_from_alignment(
         duplicate_idx = np.hstack(list(duplicates.values()))
         voice_overlap_note_ids = list(sna[duplicate_idx]["id"])
 
+    # TODO: if version > Version(1, 0, 0): sort alignment list according to perf_time before starting the for loop
+    # Note: don't use pnote_sort_info for the sorting as time mapping probably does not make a lot of sense when sections are repeated and there are section jumps
     aligned_snotes, aligned_pnotes = [], []
-    section_lines, omitted_section_lines = [], []
-    current_section_idx = -1
-    ###############################
-    #sort: # TODO: maybe sort before
-    #if use_new_format:
-    #    for al_note in alignment:
-    #        pid = al_note.get("performance_id", None)
-    #        if pid is not None:
-    #            sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
-    #        else:
-    #            sort_ptime.append(snote_sort_info[al_note["score_id"]])
-        
-    ###############################
-    # TODO: why doesn't it sort before going through the for-loop?
+
     for al_note in alignment:
         label = al_note["label"]
-        pid = al_note.get("performance_id", None)
+
         if label == "match":
             if al_note["score_id"] not in aligned_snotes and al_note["performance_id"] not in aligned_pnotes: # always true when using old_format
                 # SNOTE - PNOTE
@@ -509,10 +492,9 @@ def matchfile_from_alignment(
                 snote_note_line = MatchSnoteNote(version=version, snote=snote, note=pnote)
                 note_lines.append(snote_note_line)
                 
-                if use_new_format:
+                if version > Version(1, 0, 0):
                     aligned_snotes.append(al_note["score_id"])
                     aligned_pnotes.append(al_note["performance_id"])
-                    sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
                 else:
                     sort_stime.append(snote_sort_info[al_note["score_id"]])
             elif al_note["score_id"] in aligned_snotes and al_note["performance_id"] not in aligned_pnotes:
@@ -525,9 +507,7 @@ def matchfile_from_alignment(
                 pnote = perf_info[al_note["performance_id"]]
                 virtualSnote_note_line = MatchVirtualSnoteNote(version=version, snote=virtualSnote, note=pnote)
                 note_lines.append(virtualSnote_note_line)
-                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
-                if use_new_format:
-                    aligned_pnotes.append(al_note["performance_id"])
+                aligned_pnotes.append(al_note["performance_id"])
             elif al_note["score_id"] not in aligned_snotes and al_note["performance_id"] in aligned_pnotes:
                 # SNOTE - VIRTUAL_PNOTE
                 snote = score_info[al_note["score_id"]]
@@ -537,9 +517,7 @@ def matchfile_from_alignment(
                                 )
                 snote_virtualnote_line = MatchSnoteVirtualNote(version=version, snote=snote, note=virtualnote)
                 note_lines.append(snote_virtualnote_line)
-                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
-                if use_new_format:
-                    aligned_snotes.append(al_note["score_id"])
+                aligned_snotes.append(al_note["score_id"])
             elif al_note["score_id"] in aligned_snotes and al_note["performance_id"] in aligned_pnotes:
                 # VIRTUAL_SNOTE - VIRTUAL_PNOTE
                 virtualSnote = MatchVirtualSnote(
@@ -553,9 +531,8 @@ def matchfile_from_alignment(
                                 )
                 virtualSnote_virtualnote_line = MatchVirtualSnoteVirtualNote(version=version, snote=virtualSnote, note=virtualnote)
                 note_lines.append(virtualSnote_virtualnote_line)
-                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
 
-            if use_new_format:
+            if version > Version(1, 0, 0):
                 if al_note["score_id"] in unified_note_ids:
                     # ALIGN ALL REPEATED SNOTES TO THE VIRTUAL_PNOTE
                     min_id = note_to_min_id[al_note["score_id"]]
@@ -570,7 +547,6 @@ def matchfile_from_alignment(
                             snote = score_info[sid]
                             snote_virtualnote_line = MatchSnoteVirtualNote(version=version, snote=snote, note=virtualnote)
                             note_lines.append(snote_virtualnote_line)
-                            sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
                             aligned_snotes.append(sid)
                         else:
                             virtualSnote = MatchVirtualSnote(
@@ -580,14 +556,12 @@ def matchfile_from_alignment(
                             )
                             virtualSnote_virtualnote_line = MatchVirtualSnoteVirtualNote(version=version, snote=virtualSnote, note=virtualnote)
                             note_lines.append(virtualSnote_virtualnote_line)
-                            sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
 
         elif label == "deletion":
             skip_deletion = False
             snote = score_info[al_note["score_id"]]
-            for om_sec in omitted_sections: # for old_format omitted_sections is empty list anyhow, so no problem
+            for om_sec in omitted_sections: # nothing gets skipped if omitted_sections = []
                 if snote.OnsetInBeats > om_sec["start_in_beats_unfolded"] and snote.OnsetInBeats < om_sec["end_in_beats_unfolded"]:
-                    # TODO: is the score beat time original or unfolded here? 
                     skip_deletion = True
                     break
                 
@@ -596,18 +570,14 @@ def matchfile_from_alignment(
                     snote.ScoreAttributesList.append("voice_overlap")
                 deletion_line = MatchSnoteDeletion(version=version, snote=snote)
                 note_lines.append(deletion_line)
-                if use_new_format:
-                    sort_ptime.append(snote_sort_info[al_note["score_id"]])
-                else:
+                if version == Version(1, 0, 0):
                     sort_stime.append(snote_sort_info[al_note["score_id"]])
 
         elif label == "insertion":
             note = perf_info[al_note["performance_id"]]
             insertion_line = MatchInsertionNote(version=version, note=note)
             note_lines.append(insertion_line)
-            if use_new_format:
-                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
-            else:
+            if version == Version(1, 0, 0):
                 sort_stime.append(pnote_sort_info[al_note["performance_id"]])
 
         elif label == "ornament":
@@ -622,12 +592,11 @@ def matchfile_from_alignment(
             )
 
             note_lines.append(ornament_line)
-            if use_new_format:
-                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
-            else:
+            if version == Version(1, 0, 0):
                 sort_stime.append(pnote_sort_info[al_note["performance_id"]])
 
-    if use_new_format:
+    if version > Version(1, 0, 0):
+        section_lines, omitted_section_lines = [], []
         for sec in sections or []:
             section_line = MatchSection(
                 version=version,
@@ -654,46 +623,14 @@ def matchfile_from_alignment(
             )
             omitted_section_lines.append(omitted_section_line)
 
-    # sort notes by score onset or by performance onset (for V1.1.0) 
-    # (performed insertions are sorted
-    # according to the interpolation map
-    if use_new_format:
-        sort_time = np.array(sort_ptime) #TODO: i assume the alignment to be sorted according to ptime rn
-        #note_lines = np.array(note_lines)
-    else:
-        sort_time = np.array(sort_stime)
-        
-        sort_time_idx = np.lexsort((sort_time[:, 1], sort_time[:, 0]))  
-        note_lines = np.array(note_lines)[sort_time_idx]
     
+    if version == Version(1, 0, 0):
+        # sort notes by score onset (performed insertions are sorted
+        # according to the interpolation map
+        sort_stime = np.array(sort_stime)
+        sort_stime_idx = np.lexsort((sort_stime[:, 1], sort_stime[:, 0]))
+        note_lines = np.array(note_lines)[sort_stime_idx]
 
-    current_section_idx = -1
-    line_idx = 0
-    original_note_lines = note_lines.copy()
-
-    for note_line in original_note_lines:
-        if current_section_idx + 1 == len(sections): 
-            break
-        sec = sections[current_section_idx+1]
-        if hasattr(note_line, 'note'):
-            if hasattr(note_line.note, 'Onset'):
-                if note_line.note.Onset == sec["start_in_perf_time"]:
-                    section_line = MatchSection(
-                                        version=version,
-                                        id=sec['id'],
-                                        start_in_beats_unfolded=sec['start_in_beats_unfolded'],
-                                        end_in_beats_unfolded=sec['end_in_beats_unfolded'],
-                                        start_in_beats_original=sec['start_in_beats_original'],
-                                        end_in_beats_original=sec['end_in_beats_original'],
-                                        start_in_perf_time=sec['start_in_perf_time'],
-                                        end_in_perf_time=sec['end_in_perf_time'],
-                                        section_attr_list=sec['section_attr_list']
-                                        )
-                    note_lines = np.insert(note_lines, line_idx, section_line)
-                    line_idx += 1 # note_lines just got one line longer
-                    current_section_idx += 1
-                line_idx += 1 # we iterated to the next line
-    
     # Create match lines for pedal information
     pedal_lines = []
     for c in ppart.controls:
@@ -732,9 +669,8 @@ def matchfile_from_alignment(
             all_match_lines += scoreprop_lines[h]
 
     # Concatenate all lines
-    #all_match_lines += virtual_snote_lines + virtual_pnote_lines + section_lines + omitted_section_lines
-    #all_match_lines += section_lines 
-    all_match_lines += omitted_section_lines
+    if version > Version(1, 0, 0):
+        all_match_lines += omitted_section_lines + section_lines
     all_match_lines += list(note_lines) + pedal_lines
     matchfile = MatchFile(lines=all_match_lines)
     return matchfile
@@ -754,15 +690,11 @@ def save_match(
     score_filename: Optional[PathLike] = None,
     performance_filename: Optional[PathLike] = None,
     assume_unfolded: bool = True,
-    use_new_format: bool = False,  # New flag
+    version: tuple = (LATEST_VERSION.major, LATEST_VERSION.minor, LATEST_VERSION.patch),
     note_to_min_id: Optional[dict] = None,
     unified_note_ids: Optional[dict] = None,
-    #virtual_snote_map: Optional[dict] = None,  # New
-    #virtual_pnote_map: Optional[dict] = None,  # New
-    sections: Optional[List[dict]] = [],  # New
-    omitted_sections: Optional[List[dict]] = [],  # New
-    #minimal_section_length: float = 1.0,  # New
-    #pitch_error_threshold: bool = True,  # New
+    sections: Optional[List[dict]] = [],
+    omitted_sections: Optional[List[dict]] = [],
 ) -> Optional[MatchFile]:
     """
     Save an Alignment of a PerformedPart to a Part in a match file.
@@ -794,11 +726,17 @@ def save_match(
         Name of the file containing the score.
     performance_filename: PathLike
         Name of the (MIDI) file containing the performance.
-    assume_part_unfolded: bool
+    assume_unfolded: bool
         Whether to assume that the part has been unfolded according to the
         repetitions in the alignment. If False, the part will be automatically
         unfolded to have maximal coverage of the notes in the alignment.
         See `partitura.score.unfold_part_alignment`.
+    version: tuple: (major, minor, patch)
+        Version of the match file. For now only versions higher or equal to 1.0.0 are supported.
+    sections : list of dict or None
+        List of sections: each dict with 'id', 'start_beats_unfolded', etc.
+    omitted_sections : list of dict or None
+        List of omitted sections.
 
     Returns
     -------
@@ -844,15 +782,11 @@ def save_match(
         score_filename=score_filename,
         performance_filename=performance_filename,
         assume_part_unfolded=assume_unfolded,
-        use_new_format=use_new_format,
+        version=Version(version[0], version[1], version[2]),
         note_to_min_id=note_to_min_id,
         unified_note_ids=unified_note_ids,
-        #virtual_snote_map=virtual_snote_map,
-        #virtual_pnote_map=virtual_pnote_map,
         sections=sections,
         omitted_sections=omitted_sections,
-        #minimal_section_length=minimal_section_length,
-        #pitch_error_threshold=pitch_error_threshold,
     )
 
     if out is not None:

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -25,11 +25,16 @@ from partitura.io.matchlines_v1 import (
     MatchSnote,
     MatchNote,
     MatchSnoteNote,
+    MatchSnoteVirtualNote,
     MatchSnoteDeletion,
     MatchInsertionNote,
     MatchSustainPedal,
     MatchSoftPedal,
     MatchOrnamentNote,
+    #MatchVirtualSnote,
+    MatchVirtualPNote,
+    #MatchSection,
+    #MatchOmittedSection,
     LATEST_VERSION,
 )
 
@@ -75,6 +80,15 @@ def matchfile_from_alignment(
     tempo_indication: Optional[str] = None,
     diff_score_version_notes: Optional[list] = None,
     version: Version = LATEST_VERSION,
+    use_new_format: bool = False,  # New flag for new format
+    note_to_min_id: Optional[dict] = None,
+    unified_note_ids: Optional[dict] = None,
+    #virtual_snote_map: Optional[dict] = None,  # New: dict for virtual score notes
+    #virtual_pnote_map: Optional[dict] = None,  # New: dict for virtual perf notes
+    #sections: Optional[List[dict]] = None,  # New: list of section dicts
+    #omitted_sections: Optional[List[dict]] = None,  # New: list of omitted section dicts
+    #minimal_section_length: float = 1.0,  # New: min section length in beats
+    #pitch_error_threshold: bool = True,  # New: enable pitch error detection
     debug: bool = False,
 ) -> MatchFile:
     """
@@ -115,13 +129,30 @@ def matchfile_from_alignment(
         A list of score notes that reflect a special score version (e.g., original edition/Erstdruck, Editors note etc.)
     version: Version
         Version of the match file. For now only 1.0.0 is supported.
+    use_new_format : bool
+        If True, use the new Match format (Version 2.0.0) with virtual notes and sections.
+    virtual_snote_map : dict or None
+        Mapping for virtual score notes: {score_id: [(perf_id, attr_list), ...]}.
+    virtual_pnote_map : dict or None
+        Mapping for virtual performance notes: {perf_id: [score_id, ...]}.
+    sections : list of dict or None
+        List of sections: each dict with 'id', 'start_beats_unfolded', etc.
+    omitted_sections : list of dict or None
+        List of omitted sections.
+    minimal_section_length : float
+        Minimum length (in beats) for auto-detected sections.
+    pitch_error_threshold : bool
+        If True, detect and encode pitch errors as virtualSnotes.
     Returns
     -------
     matchfile : MatchFile
         An instance of `partitura.io.importmatch.MatchFile`.
     """
-    if version < Version(1, 0, 0):
-        raise ValueError("Version should >= 1.0.0")
+    if use_new_format:
+        version = Version(1, 1, 0)
+    else:
+        if version < Version(1, 0, 0):
+            raise ValueError("Version should >= 1.0.0")
 
     if not assume_part_unfolded:
         # unfold score according to alignment
@@ -180,8 +211,8 @@ def matchfile_from_alignment(
 
     # Measure map (which measure corresponds to which time point in divs)
     beat_map = spart.beat_map
-
-    ptime_to_stime_map, _ = get_time_maps_from_alignment(
+    
+    ptime_to_stime_map, _ = get_time_maps_from_alignment(#TODO: How much sense does that make for rehearsal?
         ppart_or_note_array=ppart.note_array(),
         spart_or_note_array=spart.note_array(),
         alignment=alignment,
@@ -277,7 +308,7 @@ def matchfile_from_alignment(
                         fifths=int(ksig.fifths),
                         mode=ksig.mode,
                         is_list=False,
-                        fmt="v1.0.0",
+                        fmt="v1.0.0",#f"v{version.major}.{version.minor}.{version.patch}",
                     ),
                     measure=int(mnum),
                     beat=beat + 1,
@@ -437,15 +468,103 @@ def matchfile_from_alignment(
         duplicate_idx = np.hstack(list(duplicates.values()))
         voice_overlap_note_ids = list(sna[duplicate_idx]["id"])
 
+    import pdb
+    pdb.set_trace()
+    ###############################
     for al_note in alignment:
         label = al_note["label"]
+        """score_id = al_note.get("score_id")
+        perf_id = al_note.get("performance_id")
+
+        if use_new_format:
+            # Handle repetitions: if score_id already matched, create virtualSnote
+            if label == "match" and score_id in matched_score_ids:
+                snote = score_info[score_id]
+                pnote = perf_info[perf_id]
+                attr_list = ["rehearsal_repetition"]  # Default; extend from virtual_snote_map if provided
+                if virtual_snote_map and score_id in virtual_snote_map:
+                    for pid, attrs in virtual_snote_map[score_id]:
+                        if pid == perf_id:
+                            attr_list = attrs
+                            break
+                virtual_snote_line = MatchVirtualSnote(
+                    version=version,
+                    anchor=score_id,
+                    attr_list=attr_list,
+                    note=pnote
+                )
+                virtual_snote_lines.append(virtual_snote_line)
+                sort_stime.append(snote_sort_info[score_id])
+                continue  # Skip standard match
+
+            # Handle pitch errors
+            if label == "match" and pitch_error_threshold:
+                snote = score_info[score_id]
+                pnote = perf_info[perf_id]
+                score_pitch = snote.octave * 12 + {'C':0,'D':2,'E':4,'F':5,'G':7,'A':9,'B':11}[snote.note_name] + snote.modifier
+                if score_pitch != pnote.midi_pitch:
+                    virtual_snote_line = MatchVirtualSnote(
+                        version=version,
+                        anchor=score_id,
+                        attr_list=["pitch_error"],
+                        note=pnote
+                    )
+                    virtual_snote_lines.append(virtual_snote_line)
+                    sort_stime.append(snote_sort_info[score_id])
+                    continue
+
+            # Handle virtualPnote for equivalent positions
+            if label == "match" and virtual_pnote_map and perf_id in virtual_pnote_map:
+                for sid in virtual_pnote_map[perf_id]:
+                    if sid != score_id:
+                        snote = score_info[sid]
+                        virtual_pnote_line = MatchVirtualPnote(
+                            version=version,
+                            snote=snote,
+                            note_id=perf_id
+                        )
+                        virtual_pnote_lines.append(virtual_pnote_line)
+                        sort_stime.append(snote_sort_info[sid])
+
+            # Track matched score_ids
+            if label == "match":
+                matched_score_ids[score_id].append(perf_id)
+
+            # Handle deletions of virtualSnotes (if score_id in repetition and deleted)
+            if label == "deletion" and score_id in matched_score_ids:
+                snote = score_info[score_id]
+                deletion_line = MatchSnoteDeletion(version=version, snote=snote)  # Reuse existing, or create virtual deletion
+                note_lines.append(deletion_line)
+                sort_stime.append(snote_sort_info[score_id])"""
 
         if label == "match":
-            snote = score_info[al_note["score_id"]]
+            snote = score_info[al_note["score_id"]] 
             pnote = perf_info[al_note["performance_id"]]
             snote_note_line = MatchSnoteNote(version=version, snote=snote, note=pnote)
             note_lines.append(snote_note_line)
             sort_stime.append(snote_sort_info[al_note["score_id"]])
+        
+
+            if use_new_format:
+                if al_note["score_id"] in unified_note_ids:
+                    min_id = note_to_min_id[al_note["score_id"]]
+                    duplicates = unified_note_ids[min_id].copy()
+                    duplicates.remove(al_note["score_id"])
+                    for sid in duplicates:
+                        snote = score_info[sid]
+                        #pdb.set_trace()
+                        virtualnote = MatchVirtualPNote(
+                                    version=version,
+                                    id=al_note["performance_id"],
+                                )
+                        snote_virtualnote_line = MatchSnoteVirtualNote(version=version, snote=snote, note=virtualnote)
+                        note_lines.append(snote_virtualnote_line)
+                        sort_stime.append(snote_sort_info[al_note["score_id"]])
+                  
+
+            #TODO: check if there exist duplicates (i.e. the len(unified_note_ids[sid])>1): if yes -> assign virtual pnote to matching p_id
+            # then assign virtual pnote to all other snotes in the unified_note_ids[sid]
+
 
         elif label == "deletion":
             snote = score_info[al_note["score_id"]]
@@ -474,6 +593,36 @@ def matchfile_from_alignment(
 
             note_lines.append(ornament_line)
             sort_stime.append(pnote_sort_info[al_note["performance_id"]])
+
+    #############################################################################
+    """# New: Add section lines
+    if use_new_format:
+        for sec in sections or []:
+            section_line = MatchSection(
+                version=version,
+                id=sec['id'],
+                start_beats_unfolded=sec['start_beats_unfolded'],
+                end_beats_unfolded=sec['end_beats_unfolded'],
+                start_beats_original=sec['start_beats_original'],
+                end_beats_original=sec['end_beats_original'],
+                start_perf_time=sec['start_perf_time'],
+                end_perf_time=sec['end_perf_time'],
+                attributes_list=sec['attributes_list']
+            )
+            section_lines.append(section_line)
+
+        for osec in omitted_sections or []:
+            omitted_section_line = MatchOmittedSection(
+                version=version,
+                id=osec['id'],
+                start_beats_unfolded=osec['start_beats_unfolded'],
+                end_beats_unfolded=osec['end_beats_unfolded'],
+                start_beats_original=osec['start_beats_original'],
+                end_beats_original=osec['end_beats_original'],
+                attributes_list=osec['attributes_list']
+            )
+            omitted_section_lines.append(omitted_section_line)"""
+    #############################################################################
 
     # sort notes by score onset (performed insertions are sorted
     # according to the interpolation map
@@ -519,6 +668,7 @@ def matchfile_from_alignment(
             all_match_lines += scoreprop_lines[h]
 
     # Concatenate all lines
+    #all_match_lines += virtual_snote_lines + virtual_pnote_lines + section_lines + omitted_section_lines
     all_match_lines += list(note_lines) + pedal_lines
     matchfile = MatchFile(lines=all_match_lines)
     return matchfile
@@ -538,6 +688,15 @@ def save_match(
     score_filename: Optional[PathLike] = None,
     performance_filename: Optional[PathLike] = None,
     assume_unfolded: bool = True,
+    use_new_format: bool = False,  # New flag
+    note_to_min_id: Optional[dict] = None,
+    unified_note_ids: Optional[dict] = None,
+    #virtual_snote_map: Optional[dict] = None,  # New
+    #virtual_pnote_map: Optional[dict] = None,  # New
+    #sections: Optional[List[dict]] = None,  # New
+    #omitted_sections: Optional[List[dict]] = None,  # New
+    #minimal_section_length: float = 1.0,  # New
+    #pitch_error_threshold: bool = True,  # New
 ) -> Optional[MatchFile]:
     """
     Save an Alignment of a PerformedPart to a Part in a match file.
@@ -619,6 +778,15 @@ def save_match(
         score_filename=score_filename,
         performance_filename=performance_filename,
         assume_part_unfolded=assume_unfolded,
+        use_new_format=use_new_format,
+        note_to_min_id=note_to_min_id,
+        unified_note_ids=unified_note_ids,
+        #virtual_snote_map=virtual_snote_map,
+        #virtual_pnote_map=virtual_pnote_map,
+        #sections=sections,
+        #omitted_sections=omitted_sections,
+        #minimal_section_length=minimal_section_length,
+        #pitch_error_threshold=pitch_error_threshold,
     )
 
     if out is not None:

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -10,7 +10,7 @@ Notes
 
 import numpy as np
 
-from typing import List, Optional, Iterable
+from typing import List, Optional, Iterable, Union
 
 from collections import defaultdict
 
@@ -82,8 +82,9 @@ def matchfile_from_alignment(
     tempo_indication: Optional[str] = None,
     diff_score_version_notes: Optional[list] = None,
     version: Version = LATEST_VERSION,
-    sections: Optional[List[dict]] = [],  # New: list of section dicts
-    omitted_sections: Optional[List[dict]] = [],  # New: list of omitted section dicts
+    sections: Optional[List[dict]] = [],
+    omitted_sections: Optional[List[dict]] = [],
+    sort_alignment: Optional[Union[str, bool]] = "default",    
     debug: bool = False,
 ) -> MatchFile:
     """
@@ -125,9 +126,12 @@ def matchfile_from_alignment(
     version: Version
         Version of the match file. For now only versions higher or equal to 1.0.0 are supported.
     sections : list of dict or None
-        List of sections: each dict with 'id', 'start_beats_unfolded', etc.
+        List of sections: each dict with 'id', 'start_in_beats_unfolded', etc.
     omitted_sections : list of dict or None
         List of omitted sections.
+    sort_alignment : str, bool, or None, optional
+        Chronological alignment sorting method: "ptime" (performance time), "stime" (score time), 
+        "default" ("ptime" if version > 1.0.0, else "stime"), or False/None (keep original order).
     Returns
     -------
     matchfile : MatchFile
@@ -191,9 +195,16 @@ def matchfile_from_alignment(
         value=int(mpq),
     )
 
+    if sort_alignment == "default":
+        if version > Version(1,0,0):
+            sort_alignment = "ptime"
+        else:
+            sort_alignment = "stime"
+
     # Measure map (which measure corresponds to which time point in divs)
     beat_map = spart.beat_map
 
+    # TODO: For rehearsals / section jumps it might make sense to have individual time mappings per section and sort accordingly
     ptime_to_stime_map, stime_to_ptime_map = get_time_maps_from_alignment(
         ppart_or_note_array=ppart.note_array(),
         spart_or_note_array=spart.note_array(),
@@ -245,7 +256,7 @@ def matchfile_from_alignment(
     # For score notes
     score_info = dict()
     # Info for sorting lines
-    snote_sort_info = dict()
+    snote_sort_info, mapped_snote_sort_info = dict(), dict()
     for (mnum, msd, msb), m in zip(measure_starts, measures):
         if mnum == 0:
             # handle offsets in anacrusis measure
@@ -415,6 +426,10 @@ def matchfile_from_alignment(
                 onset_beats,
                 snote.doc_order if snote.doc_order is not None else 0,
             )
+            mapped_snote_sort_info[snote.id] = (
+                seconds_to_midi_ticks(float(stime_to_ptime_map(onset_beats)), mpq=mpq, ppq=ppq),
+                snote.midi_pitch,
+            )
 
     # # NOTE time position is hardcoded, not pretty...  Assumes there is only one tempo indication at the beginning of the score
     if tempo_indication is not None:
@@ -433,7 +448,7 @@ def matchfile_from_alignment(
         scoreprop_lines["tempo_indication"].append(score_tempo_direction_header)
 
     perf_info = dict()
-    pnote_sort_info = dict()
+    pnote_sort_info, mapped_pnote_sort_info = dict(), dict()
     for pnote in ppart.notes:
         onset = seconds_to_midi_ticks(pnote["note_on"], mpq=mpq, ppq=ppq)
         offset = seconds_to_midi_ticks(pnote["note_off"], mpq=mpq, ppq=ppq)
@@ -451,12 +466,16 @@ def matchfile_from_alignment(
             channel=pnote.get("channel", 0),
             track=pnote.get("track", 0),
         )
-        pnote_sort_info[pnote["id"]] = (
+        mapped_pnote_sort_info[pnote["id"]] = (
             float(ptime_to_stime_map(pnote["note_on"])),
             pnote["midi_pitch"],
         )
+        pnote_sort_info[pnote["id"]] = (
+                onset,
+                pnote["midi_pitch"],
+            )
 
-    sort_stime = []
+    sort_stime, sort_ptime = [], []
     note_lines = []
 
     # Get ids of notes which voice overlap
@@ -473,38 +492,6 @@ def matchfile_from_alignment(
         duplicate_idx = np.hstack(list(duplicates.values()))
         voice_overlap_note_ids = list(sna[duplicate_idx]["id"])
 
-    # should we sort the alignment at all? Shouldn't it be the alignment algorithm's job to also define where the deletions happen in the alignment?
-    if version > Version(1, 0, 0):
-        sortable_alignment = []
-        
-        for i, al in enumerate(alignment):
-            pid = al.get("performance_id")
-            
-            if pid and pid in perf_info:
-                # Matches, Insertions, Ornaments: Use exact recorded MIDI ticks
-                onset = perf_info[pid].Onset
-                sort_key = (onset, 0, i)
-            else:
-                # map Score Time to Performance Time
-                sid = al.get("score_id")
-                snote = score_info[sid]
-                
-                # Map Score Beats -> Estimated Performance Seconds
-                est_perf_sec = float(stime_to_ptime_map(snote.OnsetInBeats))
-                # Convert Seconds -> MIDI Ticks
-                onset = seconds_to_midi_ticks(est_perf_sec, mpq=mpq, ppq=ppq)
-                
-                # '1' ensures deletions sort safely after played notes at the exact same tick
-                sort_key = (onset, 1, i)
-                
-            sortable_alignment.append((sort_key, al))
-            
-        # Sort ascending based on the keys
-        sortable_alignment.sort(key=lambda item: item[0])
-        
-        # Unpack back into the standard alignment list
-        alignment = [item[1] for item in sortable_alignment]
-
     aligned_snotes, aligned_pnotes = [], []
 
     for al_note in alignment:
@@ -514,17 +501,16 @@ def matchfile_from_alignment(
             if al_note["score_id"] not in aligned_snotes and al_note["performance_id"] not in aligned_pnotes: # always true when using old_format
                 # SNOTE - PNOTE
                 snote = score_info[al_note["score_id"]]
-                attributes_list = al_note.get("score_attributes_list", [])
-                snote.ScoreAttributesList += attributes_list
+                if version > Version(1, 0, 0):
+                    attributes_list = al_note.get("score_attributes_list", [])
+                    snote.ScoreAttributesList += attributes_list
+                    aligned_snotes.append(al_note["score_id"])
+                    aligned_pnotes.append(al_note["performance_id"])
                 pnote = perf_info[al_note["performance_id"]]
                 snote_note_line = MatchSnoteNote(version=version, snote=snote, note=pnote)
                 note_lines.append(snote_note_line)
-                
-                if version > Version(1, 0, 0):
-                    aligned_snotes.append(al_note["score_id"])
-                    aligned_pnotes.append(al_note["performance_id"])
-                else:
-                    sort_stime.append(snote_sort_info[al_note["score_id"]])
+                sort_stime.append(snote_sort_info[al_note["score_id"]])
+                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
             elif al_note["score_id"] in aligned_snotes and al_note["performance_id"] not in aligned_pnotes:
                 # VIRTUAL_SNOTE - PNOTE
                 virtualSnote = MatchVirtualSnote(
@@ -536,6 +522,8 @@ def matchfile_from_alignment(
                 virtualSnote_note_line = MatchVirtualSnoteNote(version=version, snote=virtualSnote, note=pnote)
                 note_lines.append(virtualSnote_note_line)
                 aligned_pnotes.append(al_note["performance_id"])
+                sort_stime.append(snote_sort_info[al_note["score_id"]])
+                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
             elif al_note["score_id"] not in aligned_snotes and al_note["performance_id"] in aligned_pnotes:
                 # SNOTE - VIRTUAL_PNOTE
                 snote = score_info[al_note["score_id"]]
@@ -548,6 +536,8 @@ def matchfile_from_alignment(
                 snote_virtualnote_line = MatchSnoteVirtualNote(version=version, snote=snote, note=virtualnote)
                 note_lines.append(snote_virtualnote_line)
                 aligned_snotes.append(al_note["score_id"])
+                sort_stime.append(snote_sort_info[al_note["score_id"]])
+                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
             elif al_note["score_id"] in aligned_snotes and al_note["performance_id"] in aligned_pnotes:
                 # VIRTUAL_SNOTE - VIRTUAL_PNOTE
                 virtualSnote = MatchVirtualSnote(
@@ -561,29 +551,37 @@ def matchfile_from_alignment(
                                 )
                 virtualSnote_virtualnote_line = MatchVirtualSnoteVirtualNote(version=version, snote=virtualSnote, note=virtualnote)
                 note_lines.append(virtualSnote_virtualnote_line)
+                sort_stime.append(snote_sort_info[al_note["score_id"]])
+                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
 
         elif label == "deletion":
             skip_deletion = False
             snote = score_info[al_note["score_id"]]
-            for om_sec in omitted_sections: # nothing gets skipped if omitted_sections = []
-                if snote.OnsetInBeats > om_sec["start_in_beats_unfolded"] and snote.OnsetInBeats < om_sec["end_in_beats_unfolded"]:
-                    skip_deletion = True
-                    break
+            if version > Version(1,0,0):
+                for om_sec in omitted_sections: # nothing gets skipped if omitted_sections = []
+                    if snote.OnsetInBeats > om_sec["start_in_beats_unfolded"] and snote.OnsetInBeats < om_sec["end_in_beats_unfolded"]:
+                        skip_deletion = True
+                        break
                 
             if not skip_deletion:
                 if al_note["score_id"] in voice_overlap_note_ids:
                     snote.ScoreAttributesList.append("voice_overlap")
+                if version > Version(1, 0, 0):
+                    attributes_list = al_note.get("score_attributes_list", [])
+                    snote.ScoreAttributesList += attributes_list
                 deletion_line = MatchSnoteDeletion(version=version, snote=snote)
                 note_lines.append(deletion_line)
-                if version == Version(1, 0, 0):
-                    sort_stime.append(snote_sort_info[al_note["score_id"]])
+                sort_stime.append(snote_sort_info[al_note["score_id"]])
+                sort_ptime.append(mapped_snote_sort_info[al_note["score_id"]])
+                    
 
         elif label == "insertion":
             note = perf_info[al_note["performance_id"]]
             insertion_line = MatchInsertionNote(version=version, note=note)
             note_lines.append(insertion_line)
-            if version == Version(1, 0, 0):
-                sort_stime.append(pnote_sort_info[al_note["performance_id"]])
+            sort_stime.append(mapped_pnote_sort_info[al_note["performance_id"]])
+            sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
+
 
         elif label == "ornament":
             ornament_type = al_note["type"]
@@ -597,8 +595,10 @@ def matchfile_from_alignment(
             )
 
             note_lines.append(ornament_line)
-            if version == Version(1, 0, 0):
-                sort_stime.append(pnote_sort_info[al_note["performance_id"]])
+            sort_stime.append(mapped_pnote_sort_info[al_note["performance_id"]])
+            sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
+            
+                
 
     if version > Version(1, 0, 0):
         section_lines, omitted_section_lines = [], []
@@ -628,16 +628,21 @@ def matchfile_from_alignment(
             )
             omitted_section_lines.append(omitted_section_line)
 
-    
-    if version == Version(1, 0, 0):
-        # sort notes by score onset (performed insertions are sorted
-        # according to the interpolation map
-        sort_stime = np.array(sort_stime)
-        sort_stime_idx = np.lexsort((sort_stime[:, 1], sort_stime[:, 0]))
-        note_lines = np.array(note_lines)[sort_stime_idx]
-    # Note: The alignment list is deliberately left unsorted for version > Version(1,0,0). 
-    # Sorting by performance time or score time destroys the alignment algorithm's original pathing, 
-    # tearing deletions away from their logical context and breaking structural repeats.
+    if sort_alignment:
+        if sort_alignment == "ptime":
+            sort_time = np.array(sort_ptime)
+        elif sort_alignment == "stime":
+            # sort notes by score onset (performed insertions are sorted
+            # according to the interpolation map
+            sort_time = np.array(sort_stime)
+        else:
+            raise ValueError(
+                f"Invalid sort_alignment value: '{sort_alignment}'. "
+                "Expected 'ptime', 'stime', or 'default'."
+            )
+
+        sort_time_idx = np.lexsort((sort_time[:, 1], sort_time[:, 0]))
+        note_lines = np.array(note_lines)[sort_time_idx]
 
     # Create match lines for pedal information
     pedal_lines = []
@@ -701,6 +706,7 @@ def save_match(
     version: tuple = (LATEST_VERSION.major, LATEST_VERSION.minor, LATEST_VERSION.patch),
     sections: Optional[List[dict]] = [],
     omitted_sections: Optional[List[dict]] = [],
+    sort_alignment: Optional[Union[str, bool]] = "default",
 ) -> Optional[MatchFile]:
     """
     Save an Alignment of a PerformedPart to a Part in a match file.
@@ -740,10 +746,12 @@ def save_match(
     version: tuple: (major, minor, patch)
         Version of the match file. For now only versions higher or equal to 1.0.0 are supported.
     sections : list of dict or None
-        List of sections: each dict with 'id', 'start_beats_unfolded', etc.
+        List of sections: each dict with 'id', 'start_in_beats_unfolded', etc.
     omitted_sections : list of dict or None
         List of omitted sections.
-
+    sort_alignment : str, bool, or None, optional
+        Chronological alignment sorting method: "ptime" (performance time), "stime" (score time), 
+        "default" ("ptime" if version > 1.0.0, else "stime"), or False/None (keep original order).
     Returns
     -------
     matchfile: MatchFile
@@ -791,6 +799,7 @@ def save_match(
         version=Version(version[0], version[1], version[2]),
         sections=sections,
         omitted_sections=omitted_sections,
+        sort_alignment=sort_alignment,
     )
 
     if out is not None:

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -129,18 +129,10 @@ def matchfile_from_alignment(
         Version of the match file. For now only 1.0.0 is supported.
     use_new_format : bool
         If True, use the new Match format (Version 2.0.0) with virtual notes and sections.
-    virtual_snote_map : dict or None
-        Mapping for virtual score notes: {score_id: [(perf_id, attr_list), ...]}.
-    virtual_pnote_map : dict or None
-        Mapping for virtual performance notes: {perf_id: [score_id, ...]}.
     sections : list of dict or None
         List of sections: each dict with 'id', 'start_beats_unfolded', etc.
     omitted_sections : list of dict or None
         List of omitted sections.
-    minimal_section_length : float
-        Minimum length (in beats) for auto-detected sections.
-    pitch_error_threshold : bool
-        If True, detect and encode pitch errors as virtualSnotes.
     Returns
     -------
     matchfile : MatchFile

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -31,10 +31,12 @@ from partitura.io.matchlines_v1 import (
     MatchSustainPedal,
     MatchSoftPedal,
     MatchOrnamentNote,
-    #MatchVirtualSnote,
+    MatchVirtualSnote,
     MatchVirtualPNote,
-    #MatchSection,
-    #MatchOmittedSection,
+    MatchVirtualSnoteNote,
+    MatchVirtualSnoteVirtualNote,
+    MatchSection,
+    MatchOmittedSection,
     LATEST_VERSION,
 )
 
@@ -83,12 +85,8 @@ def matchfile_from_alignment(
     use_new_format: bool = False,  # New flag for new format
     note_to_min_id: Optional[dict] = None,
     unified_note_ids: Optional[dict] = None,
-    #virtual_snote_map: Optional[dict] = None,  # New: dict for virtual score notes
-    #virtual_pnote_map: Optional[dict] = None,  # New: dict for virtual perf notes
-    #sections: Optional[List[dict]] = None,  # New: list of section dicts
-    #omitted_sections: Optional[List[dict]] = None,  # New: list of omitted section dicts
-    #minimal_section_length: float = 1.0,  # New: min section length in beats
-    #pitch_error_threshold: bool = True,  # New: enable pitch error detection
+    sections: Optional[List[dict]] = [],  # New: list of section dicts
+    omitted_sections: Optional[List[dict]] = [],  # New: list of omitted section dicts
     debug: bool = False,
 ) -> MatchFile:
     """
@@ -451,7 +449,7 @@ def matchfile_from_alignment(
             pnote["midi_pitch"],
         )
 
-    sort_stime = []
+    sort_stime, sort_ptime = [], []
     note_lines = []
 
     # Get ids of notes which voice overlap
@@ -468,117 +466,136 @@ def matchfile_from_alignment(
         duplicate_idx = np.hstack(list(duplicates.values()))
         voice_overlap_note_ids = list(sna[duplicate_idx]["id"])
 
-    import pdb
-    pdb.set_trace()
+    aligned_snotes, aligned_pnotes = [], []
+    section_lines, omitted_section_lines = [], []
+    #pdb.set_trace()
+    current_section_idx = -1
     ###############################
+    #sort: # TODO: maybe sort before
+    #if use_new_format:
+    #    for al_note in alignment:
+    #        pid = al_note.get("performance_id", None)
+    #        if pid is not None:
+    #            sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
+    #        else:
+    #            sort_ptime.append(snote_sort_info[al_note["score_id"]])
+        
+    ###############################
+    pdb.set_trace()
+    # TODO: why doesn't it sort before going through the for-loop?
     for al_note in alignment:
         label = al_note["label"]
-        """score_id = al_note.get("score_id")
-        perf_id = al_note.get("performance_id")
-
-        if use_new_format:
-            # Handle repetitions: if score_id already matched, create virtualSnote
-            if label == "match" and score_id in matched_score_ids:
-                snote = score_info[score_id]
-                pnote = perf_info[perf_id]
-                attr_list = ["rehearsal_repetition"]  # Default; extend from virtual_snote_map if provided
-                if virtual_snote_map and score_id in virtual_snote_map:
-                    for pid, attrs in virtual_snote_map[score_id]:
-                        if pid == perf_id:
-                            attr_list = attrs
-                            break
-                virtual_snote_line = MatchVirtualSnote(
-                    version=version,
-                    anchor=score_id,
-                    attr_list=attr_list,
-                    note=pnote
-                )
-                virtual_snote_lines.append(virtual_snote_line)
-                sort_stime.append(snote_sort_info[score_id])
-                continue  # Skip standard match
-
-            # Handle pitch errors
-            if label == "match" and pitch_error_threshold:
-                snote = score_info[score_id]
-                pnote = perf_info[perf_id]
-                score_pitch = snote.octave * 12 + {'C':0,'D':2,'E':4,'F':5,'G':7,'A':9,'B':11}[snote.note_name] + snote.modifier
-                if score_pitch != pnote.midi_pitch:
-                    virtual_snote_line = MatchVirtualSnote(
-                        version=version,
-                        anchor=score_id,
-                        attr_list=["pitch_error"],
-                        note=pnote
-                    )
-                    virtual_snote_lines.append(virtual_snote_line)
-                    sort_stime.append(snote_sort_info[score_id])
-                    continue
-
-            # Handle virtualPnote for equivalent positions
-            if label == "match" and virtual_pnote_map and perf_id in virtual_pnote_map:
-                for sid in virtual_pnote_map[perf_id]:
-                    if sid != score_id:
-                        snote = score_info[sid]
-                        virtual_pnote_line = MatchVirtualPnote(
-                            version=version,
-                            snote=snote,
-                            note_id=perf_id
-                        )
-                        virtual_pnote_lines.append(virtual_pnote_line)
-                        sort_stime.append(snote_sort_info[sid])
-
-            # Track matched score_ids
-            if label == "match":
-                matched_score_ids[score_id].append(perf_id)
-
-            # Handle deletions of virtualSnotes (if score_id in repetition and deleted)
-            if label == "deletion" and score_id in matched_score_ids:
-                snote = score_info[score_id]
-                deletion_line = MatchSnoteDeletion(version=version, snote=snote)  # Reuse existing, or create virtual deletion
-                note_lines.append(deletion_line)
-                sort_stime.append(snote_sort_info[score_id])"""
-
+        pid = al_note.get("performance_id", None)
         if label == "match":
-            snote = score_info[al_note["score_id"]] 
-            pnote = perf_info[al_note["performance_id"]]
-            snote_note_line = MatchSnoteNote(version=version, snote=snote, note=pnote)
-            note_lines.append(snote_note_line)
-            sort_stime.append(snote_sort_info[al_note["score_id"]])
-        
-
-            if use_new_format:
-                if al_note["score_id"] in unified_note_ids:
-                    min_id = note_to_min_id[al_note["score_id"]]
-                    duplicates = unified_note_ids[min_id].copy()
-                    duplicates.remove(al_note["score_id"])
-                    for sid in duplicates:
-                        snote = score_info[sid]
-                        #pdb.set_trace()
-                        virtualnote = MatchVirtualPNote(
+            if al_note["score_id"] not in aligned_snotes and al_note["performance_id"] not in aligned_pnotes: # always true when using old_format
+                # SNOTE - PNOTE
+                snote = score_info[al_note["score_id"]]
+                attributes_list = al_note.get("score_attributes_list", [])
+                snote.ScoreAttributesList += attributes_list
+                pnote = perf_info[al_note["performance_id"]]
+                snote_note_line = MatchSnoteNote(version=version, snote=snote, note=pnote)
+                note_lines.append(snote_note_line)
+                
+                if use_new_format:
+                    aligned_snotes.append(al_note["score_id"])
+                    aligned_pnotes.append(al_note["performance_id"])
+                    sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
+                else:
+                    sort_stime.append(snote_sort_info[al_note["score_id"]])
+            elif al_note["score_id"] in aligned_snotes and al_note["performance_id"] not in aligned_pnotes:
+                # VIRTUAL_SNOTE - PNOTE
+                virtualSnote = MatchVirtualSnote(
+                                version=version,
+                                anchor=al_note["score_id"],
+                                attributes_list=al_note.get("score_attributes_list", []),
+                            )
+                pnote = perf_info[al_note["performance_id"]]
+                virtualSnote_note_line = MatchVirtualSnoteNote(version=version, snote=virtualSnote, note=pnote)
+                note_lines.append(virtualSnote_note_line)
+                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
+                if use_new_format:
+                    aligned_pnotes.append(al_note["performance_id"])
+            elif al_note["score_id"] not in aligned_snotes and al_note["performance_id"] in aligned_pnotes:
+                # SNOTE - VIRTUAL_PNOTE
+                snote = score_info[al_note["score_id"]]
+                virtualnote = MatchVirtualPNote(
                                     version=version,
                                     id=al_note["performance_id"],
                                 )
-                        snote_virtualnote_line = MatchSnoteVirtualNote(version=version, snote=snote, note=virtualnote)
-                        note_lines.append(snote_virtualnote_line)
-                        sort_stime.append(snote_sort_info[al_note["score_id"]])
-                  
+                snote_virtualnote_line = MatchSnoteVirtualNote(version=version, snote=snote, note=virtualnote)
+                note_lines.append(snote_virtualnote_line)
+                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
+                if use_new_format:
+                    aligned_snotes.append(al_note["score_id"])
+            elif al_note["score_id"] in aligned_snotes and al_note["performance_id"] in aligned_pnotes:
+                # VIRTUAL_SNOTE - VIRTUAL_PNOTE
+                virtualSnote = MatchVirtualSnote(
+                                version=version,
+                                anchor=al_note["score_id"],
+                                attributes_list=al_note.get("score_attributes_list", []),
+                            )
+                virtualnote = MatchVirtualPNote(
+                                    version=version,
+                                    id=al_note["performance_id"],
+                                )
+                virtualSnote_virtualnote_line = MatchVirtualSnoteVirtualNote(version=version, snote=virtualSnote, note=virtualnote)
+                note_lines.append(virtualSnote_virtualnote_line)
+                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
 
-            #TODO: check if there exist duplicates (i.e. the len(unified_note_ids[sid])>1): if yes -> assign virtual pnote to matching p_id
-            # then assign virtual pnote to all other snotes in the unified_note_ids[sid]
-
+            if use_new_format:
+                if al_note["score_id"] in unified_note_ids:
+                    # ALIGN ALL REPEATED SNOTES TO THE VIRTUAL_PNOTE
+                    min_id = note_to_min_id[al_note["score_id"]]
+                    duplicates = unified_note_ids[min_id].copy()
+                    duplicates.remove(al_note["score_id"])
+                    virtualnote = MatchVirtualPNote(
+                                    version=version,
+                                    id=al_note["performance_id"],
+                                )
+                    for sid in duplicates:
+                        if sid not in aligned_snotes:
+                            snote = score_info[sid]
+                            snote_virtualnote_line = MatchSnoteVirtualNote(version=version, snote=snote, note=virtualnote)
+                            note_lines.append(snote_virtualnote_line)
+                            sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
+                            aligned_snotes.append(sid)
+                        else:
+                            virtualSnote = MatchVirtualSnote(
+                                version=version,
+                                anchor=al_note["score_id"],
+                                attributes_list=al_note.get("score_attributes_list", []),
+                            )
+                            virtualSnote_virtualnote_line = MatchVirtualSnoteVirtualNote(version=version, snote=virtualSnote, note=virtualnote)
+                            note_lines.append(virtualSnote_virtualnote_line)
+                            sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
 
         elif label == "deletion":
+            skip_deletion = False
             snote = score_info[al_note["score_id"]]
-            if al_note["score_id"] in voice_overlap_note_ids:
-                snote.ScoreAttributesList.append("voice_overlap")
-            deletion_line = MatchSnoteDeletion(version=version, snote=snote)
-            note_lines.append(deletion_line)
-            sort_stime.append(snote_sort_info[al_note["score_id"]])
+            for om_sec in omitted_sections: # for old_format omitted_sections is empty list anyhow, so no problem
+                if snote.OnsetInBeats > om_sec["start_in_beats_unfolded"] and snote.OnsetInBeats < om_sec["end_in_beats_unfolded"]:
+                    # TODO: is the score beat time original or unfolded here? 
+                    skip_deletion = True
+                    break
+                
+            if not skip_deletion:
+                if al_note["score_id"] in voice_overlap_note_ids:
+                    snote.ScoreAttributesList.append("voice_overlap")
+                deletion_line = MatchSnoteDeletion(version=version, snote=snote)
+                note_lines.append(deletion_line)
+                if use_new_format:
+                    sort_ptime.append(snote_sort_info[al_note["score_id"]])
+                else:
+                    sort_stime.append(snote_sort_info[al_note["score_id"]])
 
         elif label == "insertion":
             note = perf_info[al_note["performance_id"]]
             insertion_line = MatchInsertionNote(version=version, note=note)
             note_lines.append(insertion_line)
-            sort_stime.append(pnote_sort_info[al_note["performance_id"]])
+            if use_new_format:
+                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
+            else:
+                sort_stime.append(pnote_sort_info[al_note["performance_id"]])
 
         elif label == "ornament":
             ornament_type = al_note["type"]
@@ -592,22 +609,23 @@ def matchfile_from_alignment(
             )
 
             note_lines.append(ornament_line)
-            sort_stime.append(pnote_sort_info[al_note["performance_id"]])
+            if use_new_format:
+                sort_ptime.append(pnote_sort_info[al_note["performance_id"]])
+            else:
+                sort_stime.append(pnote_sort_info[al_note["performance_id"]])
 
-    #############################################################################
-    """# New: Add section lines
     if use_new_format:
         for sec in sections or []:
             section_line = MatchSection(
                 version=version,
                 id=sec['id'],
-                start_beats_unfolded=sec['start_beats_unfolded'],
-                end_beats_unfolded=sec['end_beats_unfolded'],
-                start_beats_original=sec['start_beats_original'],
-                end_beats_original=sec['end_beats_original'],
-                start_perf_time=sec['start_perf_time'],
-                end_perf_time=sec['end_perf_time'],
-                attributes_list=sec['attributes_list']
+                start_in_beats_unfolded=sec['start_in_beats_unfolded'],
+                end_in_beats_unfolded=sec['end_in_beats_unfolded'],
+                start_in_beats_original=sec['start_in_beats_original'],
+                end_in_beats_original=sec['end_in_beats_original'],
+                start_in_perf_time=sec['start_in_perf_time'],
+                end_in_perf_time=sec['end_in_perf_time'],
+                section_attr_list=sec['section_attr_list']
             )
             section_lines.append(section_line)
 
@@ -615,21 +633,58 @@ def matchfile_from_alignment(
             omitted_section_line = MatchOmittedSection(
                 version=version,
                 id=osec['id'],
-                start_beats_unfolded=osec['start_beats_unfolded'],
-                end_beats_unfolded=osec['end_beats_unfolded'],
-                start_beats_original=osec['start_beats_original'],
-                end_beats_original=osec['end_beats_original'],
-                attributes_list=osec['attributes_list']
+                start_in_beats_unfolded=osec['start_in_beats_unfolded'],
+                end_in_beats_unfolded=osec['end_in_beats_unfolded'],
+                start_in_beats_original=osec['start_in_beats_original'],
+                end_in_beats_original=osec['end_in_beats_original'],
+                section_attr_list=osec['section_attr_list']
             )
-            omitted_section_lines.append(omitted_section_line)"""
+            omitted_section_lines.append(omitted_section_line)
     #############################################################################
+    #pdb.set_trace()
 
-    # sort notes by score onset (performed insertions are sorted
+    # sort notes by score onset or by performance onset (for V1.1.0) 
+    # (performed insertions are sorted
     # according to the interpolation map
-    sort_stime = np.array(sort_stime)
-    sort_stime_idx = np.lexsort((sort_stime[:, 1], sort_stime[:, 0]))
-    note_lines = np.array(note_lines)[sort_stime_idx]
+    if use_new_format:
+        sort_time = np.array(sort_ptime) #TODO: i assume the alignment to be sorted according to ptime rn
+        #note_lines = np.array(note_lines)
+    else:
+        sort_time = np.array(sort_stime)
+        
+        sort_time_idx = np.lexsort((sort_time[:, 1], sort_time[:, 0]))  
+        note_lines = np.array(note_lines)[sort_time_idx]
+    
 
+    #pdb.set_trace()
+    current_section_idx = -1
+    line_idx = 0
+    original_note_lines = note_lines.copy()
+
+    for note_line in original_note_lines:
+        if current_section_idx + 1 == len(sections): 
+            break
+        sec = sections[current_section_idx+1]
+        if hasattr(note_line, 'note'):
+            if hasattr(note_line.note, 'Onset'):
+                if note_line.note.Onset == sec["start_in_perf_time"]:
+                    section_line = MatchSection(
+                                        version=version,
+                                        id=sec['id'],
+                                        start_in_beats_unfolded=sec['start_in_beats_unfolded'],
+                                        end_in_beats_unfolded=sec['end_in_beats_unfolded'],
+                                        start_in_beats_original=sec['start_in_beats_original'],
+                                        end_in_beats_original=sec['end_in_beats_original'],
+                                        start_in_perf_time=sec['start_in_perf_time'],
+                                        end_in_perf_time=sec['end_in_perf_time'],
+                                        section_attr_list=sec['section_attr_list']
+                                        )
+                    note_lines = np.insert(note_lines, line_idx, section_line)
+                    line_idx += 1 # note_lines just got one line longer
+                    current_section_idx += 1
+                line_idx += 1 # we iterated to the next line
+    
+    #pdb.set_trace()
     # Create match lines for pedal information
     pedal_lines = []
     for c in ppart.controls:
@@ -669,6 +724,8 @@ def matchfile_from_alignment(
 
     # Concatenate all lines
     #all_match_lines += virtual_snote_lines + virtual_pnote_lines + section_lines + omitted_section_lines
+    #all_match_lines += section_lines 
+    all_match_lines += omitted_section_lines
     all_match_lines += list(note_lines) + pedal_lines
     matchfile = MatchFile(lines=all_match_lines)
     return matchfile
@@ -693,8 +750,8 @@ def save_match(
     unified_note_ids: Optional[dict] = None,
     #virtual_snote_map: Optional[dict] = None,  # New
     #virtual_pnote_map: Optional[dict] = None,  # New
-    #sections: Optional[List[dict]] = None,  # New
-    #omitted_sections: Optional[List[dict]] = None,  # New
+    sections: Optional[List[dict]] = [],  # New
+    omitted_sections: Optional[List[dict]] = [],  # New
     #minimal_section_length: float = 1.0,  # New
     #pitch_error_threshold: bool = True,  # New
 ) -> Optional[MatchFile]:
@@ -783,8 +840,8 @@ def save_match(
         unified_note_ids=unified_note_ids,
         #virtual_snote_map=virtual_snote_map,
         #virtual_pnote_map=virtual_pnote_map,
-        #sections=sections,
-        #omitted_sections=omitted_sections,
+        sections=sections,
+        omitted_sections=omitted_sections,
         #minimal_section_length=minimal_section_length,
         #pitch_error_threshold=pitch_error_threshold,
     )

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -473,6 +473,37 @@ def matchfile_from_alignment(
         duplicate_idx = np.hstack(list(duplicates.values()))
         voice_overlap_note_ids = list(sna[duplicate_idx]["id"])
 
+    # should we sort the alignment at all? Shouldn't it be the alignment algorithm's job to also define where the deletions happen in the alignment?
+    if version > Version(1, 0, 0):
+        sortable_alignment = []
+        
+        for i, al in enumerate(alignment):
+            pid = al.get("performance_id")
+            
+            if pid and pid in perf_info:
+                # Matches, Insertions, Ornaments: Use exact recorded MIDI ticks
+                onset = perf_info[pid].Onset
+                sort_key = (onset, 0, i)
+            else:
+                # map Score Time to Performance Time
+                sid = al.get("score_id")
+                snote = score_info[sid]
+                
+                # Map Score Beats -> Estimated Performance Seconds
+                est_perf_sec = float(stime_to_ptime_map(snote.OnsetInBeats))
+                # Convert Seconds -> MIDI Ticks
+                onset = seconds_to_midi_ticks(est_perf_sec, mpq=mpq, ppq=ppq)
+                
+                # '1' ensures deletions sort safely after played notes at the exact same tick
+                sort_key = (onset, 1, i)
+                
+            sortable_alignment.append((sort_key, al))
+            
+        # Sort ascending based on the keys
+        sortable_alignment.sort(key=lambda item: item[0])
+        
+        # Unpack back into the standard alignment list
+        alignment = [item[1] for item in sortable_alignment]
 
     aligned_snotes, aligned_pnotes = [], []
 
@@ -508,6 +539,8 @@ def matchfile_from_alignment(
             elif al_note["score_id"] not in aligned_snotes and al_note["performance_id"] in aligned_pnotes:
                 # SNOTE - VIRTUAL_PNOTE
                 snote = score_info[al_note["score_id"]]
+                attributes_list = al_note.get("score_attributes_list", [])
+                snote.ScoreAttributesList += attributes_list
                 virtualnote = MatchVirtualPNote(
                                     version=version,
                                     id=al_note["performance_id"],

--- a/partitura/io/exportmatch.py
+++ b/partitura/io/exportmatch.py
@@ -194,7 +194,7 @@ def matchfile_from_alignment(
     # Measure map (which measure corresponds to which time point in divs)
     beat_map = spart.beat_map
 
-    ptime_to_stime_map, _ = get_time_maps_from_alignment(
+    ptime_to_stime_map, stime_to_ptime_map = get_time_maps_from_alignment(
         ppart_or_note_array=ppart.note_array(),
         spart_or_note_array=spart.note_array(),
         alignment=alignment,
@@ -475,6 +475,40 @@ def matchfile_from_alignment(
 
     # TODO: if version > Version(1, 0, 0): sort alignment list according to perf_time before starting the for loop
     # Note: don't use pnote_sort_info for the sorting as time mapping probably does not make a lot of sense when sections are repeated and there are section jumps
+    # Sort alignment list according to perf_time before starting the loop for newer versions
+    
+    # should we sort the alignment at all? Shouldn't it be the alignment algorithm's job to also define where the deletions happen in the alignment?
+    if version > Version(1, 0, 0):
+        sortable_alignment = []
+        
+        for i, al in enumerate(alignment):
+            pid = al.get("performance_id")
+            
+            if pid and pid in perf_info:
+                # Matches, Insertions, Ornaments: Use exact recorded MIDI ticks
+                onset = perf_info[pid].Onset
+                sort_key = (onset, 0, i)
+            else:
+                # map Score Time to Performance Time
+                sid = al.get("score_id")
+                snote = score_info[sid]
+                
+                # Map Score Beats -> Estimated Performance Seconds
+                est_perf_sec = float(stime_to_ptime_map(snote.OnsetInBeats))
+                # Convert Seconds -> MIDI Ticks
+                onset = seconds_to_midi_ticks(est_perf_sec, mpq=mpq, ppq=ppq)
+                
+                # '1' ensures deletions sort safely after played notes at the exact same tick
+                sort_key = (onset, 1, i)
+                
+            sortable_alignment.append((sort_key, al))
+            
+        # Sort ascending based on the keys
+        sortable_alignment.sort(key=lambda item: item[0])
+        
+        # Unpack back into the standard alignment list
+        alignment = [item[1] for item in sortable_alignment]
+
     aligned_snotes, aligned_pnotes = [], []
 
     for al_note in alignment:

--- a/partitura/io/matchfile_base.py
+++ b/partitura/io/matchfile_base.py
@@ -678,6 +678,25 @@ class BaseNoteLine(MatchLine):
     @property
     def Duration(self):
         return self.Offset - self.Onset
+    
+class VirtualNoteLine(MatchLine):
+    # All derived classes should include at least
+    # these field names
+    field_names = (
+        "Id",
+    )
+
+    field_types = (
+        str,
+    )
+
+    def __init__(
+        self,
+        version: Version,
+        id: str,
+    ) -> None:
+        super().__init__(version)
+        self.Id = id
 
 
 class BaseSnoteNoteLine(MatchLine):
@@ -755,6 +774,94 @@ class BaseSnoteNoteLine(MatchLine):
         matchline: str,
         snote_class: BaseSnoteLine,
         note_class: BaseNoteLine,
+        version: Version,
+    ) -> Dict:
+        snote = snote_class.from_matchline(matchline, version=version)
+        note = note_class.from_matchline(matchline, version=version)
+
+        kwargs = dict(
+            version=version,
+            snote=snote,
+            note=note,
+        )
+
+        return kwargs
+    
+class BaseSnoteVirtualNoteLine(MatchLine):
+    out_pattern = "{SnoteLine}-{VirtualNoteLine}"
+
+    def __init__(
+        self,
+        version: Version,
+        snote: BaseSnoteLine,
+        note: VirtualNoteLine,
+    ) -> None:
+        super().__init__(version)
+
+        self.snote = snote
+        self.note = note
+
+        self.field_names = self.snote.field_names + self.note.field_names
+
+        self.field_types = self.snote.field_types + self.note.field_types
+
+        self.pattern = (self.snote.pattern, self.note.pattern)
+
+        self.format_fun = (self.snote.format_fun, self.note.format_fun)
+
+    @property
+    def matchline(self) -> str:
+        return self.out_pattern.format(
+            SnoteLine=self.snote.matchline,
+            VirtualNoteLine=self.note.matchline,
+        )
+
+    def __str__(self) -> str:
+        """
+        Prints the printing the match line
+        """
+        r = [self.__class__.__name__]
+        r += [" Snote"] + [
+            "   {0}: {1}".format(fn, getattr(self.snote, fn, None))
+            for fn in self.snote.field_names
+        ]
+
+        r += [" Note"] + [
+            "   {0}: {1}".format(fn, getattr(self.note, fn, None))
+            for fn in self.note.field_names
+        ]
+
+        return "\n".join(r) + "\n"
+
+    def check_types(self, verbose: bool = False) -> bool:
+        """
+        Check whether the values of the fields are of the correct type.
+
+        Parameters
+        ----------
+        verbose : bool
+            Prints whether each of the attributes in field_names has the correct dtype.
+            values are
+
+        Returns
+        -------
+        types_are_correct : bool
+            True if the values of all fields in the match line have the
+            correct type.
+        """
+        snote_types_are_correct = self.snote.check_types(verbose)
+        note_types_are_correct = self.note.check_types(verbose)
+
+        types_are_correct = snote_types_are_correct and note_types_are_correct
+
+        return types_are_correct
+
+    @classmethod
+    def prepare_kwargs_from_matchline(
+        cls,
+        matchline: str,
+        snote_class: BaseSnoteLine,
+        note_class: VirtualNoteLine,
         version: Version,
     ) -> Dict:
         snote = snote_class.from_matchline(matchline, version=version)

--- a/partitura/io/matchfile_base.py
+++ b/partitura/io/matchfile_base.py
@@ -638,6 +638,90 @@ class BaseSnoteLine(MatchLine):
             raise MatchError("Input match line does not fit the expected pattern.")
 
 
+# deprecate bar for measure
+class VirtualSnoteLine(MatchLine):
+    """
+    Base class to represent score notes.
+
+    Parameters
+    ----------
+    version: Version
+    anchor: str
+    attributes_list: List[str]
+
+    Attributes
+    ----------
+
+    Notes
+    -----
+    """
+
+    # All derived classes should include
+    # at least these field names
+    field_names = (
+        "Anchor",
+        "AttributesList",
+    )
+
+    field_types = (
+        str,
+        list,
+    )
+
+    out_pattern = (
+        "virtualSnote({Anchor},{AttributesList})"
+    )
+
+    pattern = re.compile(
+        r"virtualSnote\("
+        r"(?P<Anchor>[^,]+),"
+        r"\[(?P<AttributesList>.*)\]\)"
+    )
+
+    format_fun = dict(
+        Anchor=format_string,
+        AttributesList=format_list,
+    )
+
+    def __init__(
+        self,
+        version: Version,
+        anchor: str,
+        attributes_list: List[str],
+    ) -> None:
+        super().__init__(version)
+
+        # All of these attributes should have the
+        # correct dtype (otherwise we need to be constantly
+        # checking the types).
+        self.Anchor = anchor
+        self.AttributesList = attributes_list
+
+    @classmethod
+    def prepare_kwargs_from_matchline(
+        cls,
+        matchline: str,
+        pos: int = 0,
+    ) -> Dict:
+        match_pattern = cls.pattern.search(matchline, pos)
+
+        if match_pattern is not None:
+            (
+                anchor_str,
+                attributes_list_str,
+            ) = match_pattern.groups()
+
+            anchor = interpret_as_string(anchor_str)
+
+            return dict(
+                anchor=interpret_as_string(anchor),
+                attributes_list=interpret_as_list(attributes_list_str),
+            )
+
+        else:
+            raise MatchError("Input match line does not fit the expected pattern.")
+        
+
 class BaseNoteLine(MatchLine):
     # All derived classes should include at least
     # these field names
@@ -861,6 +945,184 @@ class BaseSnoteVirtualNoteLine(MatchLine):
         cls,
         matchline: str,
         snote_class: BaseSnoteLine,
+        note_class: VirtualNoteLine,
+        version: Version,
+    ) -> Dict:
+        snote = snote_class.from_matchline(matchline, version=version)
+        note = note_class.from_matchline(matchline, version=version)
+
+        kwargs = dict(
+            version=version,
+            snote=snote,
+            note=note,
+        )
+
+        return kwargs
+    
+
+class VirtualSnoteNoteLine(MatchLine):
+    out_pattern = "{VirtualSnoteLine}-{NoteLine}"
+
+    def __init__(
+        self,
+        version: Version,
+        snote: VirtualSnoteLine,
+        note: BaseNoteLine,
+    ) -> None:
+        super().__init__(version)
+
+        self.snote = snote
+        self.note = note
+
+        self.field_names = self.snote.field_names + self.note.field_names
+
+        self.field_types = self.snote.field_types + self.note.field_types
+
+        self.pattern = (self.snote.pattern, self.note.pattern)
+
+        self.format_fun = (self.snote.format_fun, self.note.format_fun)
+
+    @property
+    def matchline(self) -> str:
+        return self.out_pattern.format(
+            VirtualSnoteLine=self.snote.matchline,
+            NoteLine=self.note.matchline,
+        )
+
+    def __str__(self) -> str:
+        """
+        Prints the printing the match line
+        """
+        r = [self.__class__.__name__]
+        r += [" Snote"] + [
+            "   {0}: {1}".format(fn, getattr(self.snote, fn, None))
+            for fn in self.snote.field_names
+        ]
+
+        r += [" Note"] + [
+            "   {0}: {1}".format(fn, getattr(self.note, fn, None))
+            for fn in self.note.field_names
+        ]
+
+        return "\n".join(r) + "\n"
+
+    def check_types(self, verbose: bool = False) -> bool:
+        """
+        Check whether the values of the fields are of the correct type.
+
+        Parameters
+        ----------
+        verbose : bool
+            Prints whether each of the attributes in field_names has the correct dtype.
+            values are
+
+        Returns
+        -------
+        types_are_correct : bool
+            True if the values of all fields in the match line have the
+            correct type.
+        """
+        snote_types_are_correct = self.snote.check_types(verbose)
+        note_types_are_correct = self.note.check_types(verbose)
+
+        types_are_correct = snote_types_are_correct and note_types_are_correct
+
+        return types_are_correct
+
+    @classmethod
+    def prepare_kwargs_from_matchline(
+        cls,
+        matchline: str,
+        snote_class: VirtualSnoteLine,
+        note_class: BaseNoteLine,
+        version: Version,
+    ) -> Dict:
+        snote = snote_class.from_matchline(matchline, version=version)
+        note = note_class.from_matchline(matchline, version=version)
+
+        kwargs = dict(
+            version=version,
+            snote=snote,
+            note=note,
+        )
+
+        return kwargs
+    
+
+class VirtualSnoteVirtualNoteLine(MatchLine):
+    out_pattern = "{VirtualSnoteLine}-{VirtualNoteLine}"
+
+    def __init__(
+        self,
+        version: Version,
+        snote: VirtualSnoteLine,
+        note: VirtualNoteLine,
+    ) -> None:
+        super().__init__(version)
+
+        self.snote = snote
+        self.note = note
+
+        self.field_names = self.snote.field_names + self.note.field_names
+
+        self.field_types = self.snote.field_types + self.note.field_types
+
+        self.pattern = (self.snote.pattern, self.note.pattern)
+
+        self.format_fun = (self.snote.format_fun, self.note.format_fun)
+
+    @property
+    def matchline(self) -> str:
+        return self.out_pattern.format(
+            VirtualSnoteLine=self.snote.matchline,
+            VirtualNoteLine=self.note.matchline,
+        )
+
+    def __str__(self) -> str:
+        """
+        Prints the printing the match line
+        """
+        r = [self.__class__.__name__]
+        r += [" Snote"] + [
+            "   {0}: {1}".format(fn, getattr(self.snote, fn, None))
+            for fn in self.snote.field_names
+        ]
+
+        r += [" Note"] + [
+            "   {0}: {1}".format(fn, getattr(self.note, fn, None))
+            for fn in self.note.field_names
+        ]
+
+        return "\n".join(r) + "\n"
+
+    def check_types(self, verbose: bool = False) -> bool:
+        """
+        Check whether the values of the fields are of the correct type.
+
+        Parameters
+        ----------
+        verbose : bool
+            Prints whether each of the attributes in field_names has the correct dtype.
+            values are
+
+        Returns
+        -------
+        types_are_correct : bool
+            True if the values of all fields in the match line have the
+            correct type.
+        """
+        snote_types_are_correct = self.snote.check_types(verbose)
+        note_types_are_correct = self.note.check_types(verbose)
+
+        types_are_correct = snote_types_are_correct and note_types_are_correct
+
+        return types_are_correct
+
+    @classmethod
+    def prepare_kwargs_from_matchline(
+        cls,
+        matchline: str,
+        snote_class: VirtualSnoteLine,
         note_class: VirtualNoteLine,
         version: Version,
     ) -> Dict:

--- a/partitura/io/matchlines_v1.py
+++ b/partitura/io/matchlines_v1.py
@@ -27,7 +27,9 @@ from partitura.io.matchfile_base import (
     BasePtimeLine,
     BaseStimePtimeLine,
     BaseNoteLine,
+    VirtualNoteLine,
     BaseSnoteNoteLine,
+    BaseSnoteVirtualNoteLine,
     BaseDeletionLine,
     BaseInsertionLine,
     BaseOrnamentLine,
@@ -101,6 +103,8 @@ INFO_LINE = {
         "subtitle": (interpret_as_string, format_string, str),
     }
 }
+
+INFO_LINE[Version(1, 1, 0)] = INFO_LINE[Version(1, 0, 0)]
 
 INFO_ATTRIBUTE_EQUIVALENCES = dict(
     midiFilename="midiFileName",
@@ -250,6 +254,8 @@ SCOREPROP_LINE = {
         "directions": (interpret_as_list, format_list, list),
     }
 }
+
+SCOREPROP_LINE[Version(1, 1, 0)] = SCOREPROP_LINE[Version(1, 0, 0)]
 
 SCOREPROP_ATTRIBUTE_EQUIVALENCES = dict(
     beatSubdivision="beatSubDivision",
@@ -809,6 +815,8 @@ NOTE_LINE = {
     }
 }
 
+NOTE_LINE[Version(1, 1, 0)] = NOTE_LINE[Version(1, 0, 0)]
+
 
 class MatchNote(BaseNoteLine):
     field_names = (
@@ -917,6 +925,90 @@ class MatchNote(BaseNoteLine):
                 track=0,
             )
 
+###############################################################################################################################################
+class MatchVirtualPNote(VirtualNoteLine):
+    field_names = (
+        "Id",
+    )
+
+    out_pattern = (
+        "note({Id},)."
+    )
+
+    pattern = re.compile(
+        r"note\((?P<Id>[^,]+),"
+    )
+
+    def __init__(
+        self,
+        version: Version,
+        id: str,
+    ) -> None:
+        if version not in NOTE_LINE:
+            raise ValueError(
+                f"Unknown version {version}!. "
+                f"Supported versions are {list(NOTE_LINE.keys())}"
+            )
+
+        super().__init__(
+            version=version,
+            id=id,
+        )
+
+        self.field_types = tuple(NOTE_LINE[version][fn][2] for fn in self.field_names)
+        self.format_fun = dict(
+            [(fn, NOTE_LINE[version][fn][1]) for fn in self.field_names]
+        )
+
+    @classmethod
+    def from_matchline(
+        cls,
+        matchline: str,
+        pos: int = 0,
+        version: Version = LATEST_VERSION,
+    ) -> MatchNote:
+        if version < Version(1, 0, 0):
+            raise ValueError(f"{version} < Version(1, 0, 0)")
+
+        kwargs = get_kwargs_from_matchline(
+            matchline=matchline,
+            pattern=cls.pattern,
+            field_names=cls.field_names,
+            class_dict=NOTE_LINE[version],
+            pos=pos,
+        )
+
+        if kwargs is not None:
+            return cls(version=version, **kwargs)
+
+        else:
+            raise MatchError("Input match line does not fit the expected pattern.")
+
+    @classmethod
+    def from_instance(
+        cls,
+        instance: BaseNoteLine,
+        version: Version = LATEST_VERSION,
+    ) -> MatchNote:
+        if version < Version(1, 0, 0):
+            raise ValueError(f"{version} < Version(1, 0, 0)")
+
+        if not isinstance(instance, BaseNoteLine):
+            raise ValueError("`instance` needs to be a subclass of `BaseNoteLine`")
+
+        if instance.version < Version(1, 0, 0):
+            return cls(
+                version=version,
+                id=instance.Id,
+                midi_pitch=instance.MidiPitch,
+                onset=int(np.round(instance.Onset)),
+                offset=int(np.round(instance.Offset)),
+                velocity=instance.Velocity,
+                channel=1,
+                track=0,
+            )
+
+###############################################################################################################################################
 
 class MatchStimePtime(BaseStimePtimeLine):
     def __init__(
@@ -995,6 +1087,53 @@ class MatchSnoteNote(BaseSnoteNoteLine):
             version=version,
             snote=MatchSnote.from_instance(instance.snote, version=version),
             note=MatchNote.from_instance(instance.note, version=version),
+        )
+    
+class MatchSnoteVirtualNote(BaseSnoteVirtualNoteLine):
+    def __init__(
+        self,
+        version: Version,
+        snote: BaseSnoteLine,
+        note: VirtualNoteLine,
+    ) -> None:
+        super().__init__(
+            version=version,
+            snote=snote,
+            note=note,
+        )
+
+    @classmethod
+    def from_matchline(
+        cls,
+        matchline: str,
+        version: Version = LATEST_VERSION,
+    ) -> MatchSnoteVirtualNote:
+        if version < Version(1, 0, 0):
+            raise ValueError(f"{version} < Version(1, 0, 0)")
+
+        kwargs = cls.prepare_kwargs_from_matchline(
+            matchline=matchline,
+            snote_class=MatchSnote,
+            note_class=MatchVirtualPNote,
+            version=version,
+        )
+
+        return cls(**kwargs)
+
+    @classmethod
+    def from_instance(
+        cls, instance: BaseSnoteVirtualNoteLine, version: Version
+    ) -> MatchSnoteVirtualNote:
+        if version < Version(1, 0, 0):
+            raise ValueError(f"{version} < Version(1, 0, 0)")
+
+        if not isinstance(instance, BaseSnoteVirtualNoteLine):
+            raise ValueError("`instance` needs to be a subclass of `BaseSnoteVirtualNoteLine`")
+
+        return cls(
+            version=version,
+            snote=MatchSnote.from_instance(instance.snote, version=version),
+            note=MatchVirtualPNote.from_instance(instance.note, version=version),
         )
 
 

--- a/partitura/io/matchlines_v1.py
+++ b/partitura/io/matchlines_v1.py
@@ -27,7 +27,10 @@ from partitura.io.matchfile_base import (
     BasePtimeLine,
     BaseStimePtimeLine,
     BaseNoteLine,
+    VirtualSnoteLine,
     VirtualNoteLine,
+    VirtualSnoteNoteLine,
+    VirtualSnoteVirtualNoteLine,
     BaseSnoteNoteLine,
     BaseSnoteVirtualNoteLine,
     BaseDeletionLine,
@@ -469,6 +472,16 @@ SECTION_LINE = {
         "StartInBeatsOriginal": (interpret_as_float, format_float, float),
         "EndInBeatsOriginal": (interpret_as_float, format_float, float),
         "RepeatEndType": (interpret_as_list, format_list, list),
+    },
+    Version(1, 1, 0): {
+        "id": (interpret_as_string, format_string, str),
+        "StartInBeatsUnfolded": (interpret_as_float, format_float, float),
+        "EndInBeatsUnfolded": (interpret_as_float, format_float, float),
+        "StartInBeatsOriginal": (interpret_as_float, format_float, float),
+        "EndInBeatsOriginal": (interpret_as_float, format_float, float),
+        "StartInPerfTime": (interpret_as_int, format_int, int),
+        "EndInPerfTime": (interpret_as_int, format_int, int),
+        "SectionAttrList": (interpret_as_list, format_list, list),
     }
 }
 
@@ -477,7 +490,11 @@ class MatchSection(MatchLine):
     """
     Class for specifiying structural information (i.e., sections).
 
+    For version 1.0.0:
     section(StartInBeatsUnfolded,EndInBeatsUnfolded,StartInBeatsOriginal,EndInBeatsOriginal,RepeatEndType).
+
+    For version 1.1.0:
+    section(id, StartInBeatsUnfolded,EndInBeatsUnfolded,StartInBeatsOriginal,EndInBeatsOriginal,StartInPerfTime,EndInPerfTime,SectionAttrList).
 
     Parameters
     ----------
@@ -486,29 +503,32 @@ class MatchSection(MatchLine):
     end_in_beats_unfolded: float,
     start_in_beats_original: float,
     end_in_beats_original: float,
-    repeat_end_type: List[str]
+    repeat_end_type: List[str] (for version 1.0.0, optional)
+    id: str (for version 1.1.0, optional)
+    start_in_perf_time: int (for version 1.1.0, optional)
+    end_in_perf_time: int (for version 1.1.0, optional)
+    section_attr_list: List[str] (for version 1.1.0, optional)
     """
 
-    field_names = (
-        "StartInBeatsUnfolded",
-        "EndInBeatsUnfolded",
-        "StartInBeatsOriginal",
-        "EndInBeatsOriginal",
-        "RepeatEndType",
-    )
-
-    out_pattern = (
-        "section({StartInBeatsUnfolded},"
-        "{EndInBeatsUnfolded},{StartInBeatsOriginal},"
-        "{EndInBeatsOriginal},{RepeatEndType})."
-    )
-    pattern = re.compile(
+    pattern_v1_0_0 = re.compile(
         r"section\("
         r"(?P<StartInBeatsUnfolded>[^,]+),"
         r"(?P<EndInBeatsUnfolded>[^,]+),"
         r"(?P<StartInBeatsOriginal>[^,]+),"
         r"(?P<EndInBeatsOriginal>[^,]+),"
         r"\[(?P<RepeatEndType>.*)\]\)."
+    )
+
+    pattern_v1_1_0 = re.compile(
+        r"section\("
+        r"(?P<id>[^,]+),"
+        r"(?P<StartInBeatsUnfolded>[^,]+),"
+        r"(?P<EndInBeatsUnfolded>[^,]+),"
+        r"(?P<StartInBeatsOriginal>[^,]+),"
+        r"(?P<EndInBeatsOriginal>[^,]+),"
+        r"(?P<StartInPerfTime>[^,]+),"
+        r"(?P<EndInPerfTime>[^,]+),"
+        r"\[(?P<SectionAttrList>.*)\]\)."
     )
 
     def __init__(
@@ -518,7 +538,142 @@ class MatchSection(MatchLine):
         end_in_beats_unfolded: float,
         start_in_beats_original: float,
         end_in_beats_original: float,
-        repeat_end_type: List[str],
+        repeat_end_type: Optional[List[str]] = None,
+        id: Optional[str] = None,
+        start_in_perf_time: Optional[int] = None,
+        end_in_perf_time: Optional[int] = None,
+        section_attr_list: Optional[List[str]] = None,
+    ) -> None:
+        if version not in SECTION_LINE:
+            raise ValueError(
+                f"Unknown version {version}!. "
+                f"Supported versions are {list(SECTION_LINE.keys())}"
+            )
+        super().__init__(version)
+
+        self.field_names = tuple(SECTION_LINE[version].keys())
+        self.field_types = tuple(
+            SECTION_LINE[version][fn][2] for fn in self.field_names
+        )
+        self.format_fun = dict(
+            [(fn, ft[1]) for fn, ft in SECTION_LINE[version].items()]
+        )
+
+        self.StartInBeatsUnfolded = start_in_beats_unfolded
+        self.EndInBeatsUnfolded = end_in_beats_unfolded
+        self.StartInBeatsOriginal = start_in_beats_original
+        self.EndInBeatsOriginal = end_in_beats_original
+
+        if version == Version(1, 0, 0):
+            self.RepeatEndType = repeat_end_type
+            self.out_pattern = (
+                "section({StartInBeatsUnfolded},"
+                "{EndInBeatsUnfolded},{StartInBeatsOriginal},"
+                "{EndInBeatsOriginal},{RepeatEndType})."
+            )
+            self.pattern = self.pattern_v1_0_0
+        elif version == Version(1, 1, 0):
+            self.id = id
+            self.StartInPerfTime = start_in_perf_time
+            self.EndInPerfTime = end_in_perf_time
+            self.SectionAttrList = section_attr_list
+            self.out_pattern = (
+                "section({id},{StartInBeatsUnfolded},"
+                "{EndInBeatsUnfolded},{StartInBeatsOriginal},"
+                "{EndInBeatsOriginal},{StartInPerfTime},"
+                "{EndInPerfTime},{SectionAttrList})."
+            )
+            self.pattern = self.pattern_v1_1_0
+
+    @classmethod
+    def from_matchline(
+        cls,
+        matchline: str,
+        pos: int = 0,
+        version: Version = LATEST_VERSION,
+    ) -> MatchSection:
+        if version not in SECTION_LINE:
+            raise ValueError(
+                f"Unknown version {version}!. "
+                f"Supported versions are {list(SECTION_LINE.keys())}"
+            )
+
+        class_dict = SECTION_LINE[version]
+
+        # Select the appropriate pattern based on version
+        if version == Version(1, 0, 0):
+            pattern = cls.pattern_v1_0_0
+        elif version == Version(1, 1, 0):
+            pattern = cls.pattern_v1_1_0
+        else:
+            pattern = cls.pattern_v1_0_0
+
+        match_pattern = pattern.search(matchline, pos=pos)
+
+        if match_pattern is not None:
+            kwargs = dict(
+                [
+                    (to_snake_case(fn), class_dict[fn][0](match_pattern.group(fn)))
+                    for fn in class_dict.keys()
+                ]
+            )
+
+            return cls(version=version, **kwargs)
+
+        else:
+            raise MatchError("Input match line does not fit the expected pattern.")
+
+
+class MatchOmittedSection(MatchLine):
+    """
+    Class for specifiying structural information (i.e., sections).
+
+    section(StartInBeatsUnfolded,EndInBeatsUnfolded,StartInBeatsOriginal,EndInBeatsOriginal,RepeatEndType).
+
+    Parameters
+    ----------
+    version: Version,
+    id: str,
+    start_in_beats_unfolded: float,
+    end_in_beats_unfolded: float,
+    start_in_beats_original: float,
+    end_in_beats_original: float,
+    section_attr_list: List[str]
+    """
+
+    field_names = (
+        "id",
+        "StartInBeatsUnfolded",
+        "EndInBeatsUnfolded",
+        "StartInBeatsOriginal",
+        "EndInBeatsOriginal",
+        "SectionAttrList",
+    )
+
+    out_pattern = (
+        "omittedSection({id},{StartInBeatsUnfolded},"
+        "{EndInBeatsUnfolded},{StartInBeatsOriginal},"
+        "{EndInBeatsOriginal},{SectionAttrList})."
+    )
+    pattern = re.compile(
+        r"section\("
+        r"(?P<id>[^,]+),"
+        r"(?P<StartInBeatsUnfolded>[^,]+),"
+        r"(?P<EndInBeatsUnfolded>[^,]+),"
+        r"(?P<StartInBeatsOriginal>[^,]+),"
+        r"(?P<EndInBeatsOriginal>[^,]+),"
+        r"\[(?P<SectionAttrList>.*)\]\)."
+    )
+
+    def __init__(
+        self,
+        version: Version,
+        id: str,
+        start_in_beats_unfolded: float,
+        end_in_beats_unfolded: float,
+        start_in_beats_original: float,
+        end_in_beats_original: float,
+        section_attr_list: List[str],
     ) -> None:
         if version not in SECTION_LINE:
             raise ValueError(
@@ -534,11 +689,12 @@ class MatchSection(MatchLine):
             [(fn, ft[1]) for fn, ft in SECTION_LINE[version].items()]
         )
 
+        self.id = id
         self.StartInBeatsUnfolded = start_in_beats_unfolded
         self.EndInBeatsUnfolded = end_in_beats_unfolded
         self.StartInBeatsOriginal = start_in_beats_original
         self.EndInBeatsOriginal = end_in_beats_original
-        self.RepeatEndType = repeat_end_type
+        self.SectionAttrList = section_attr_list
 
     @classmethod
     def from_matchline(
@@ -568,7 +724,7 @@ class MatchSection(MatchLine):
 
         else:
             raise MatchError("Input match line does not fit the expected pattern.")
-
+      
 
 STIME_LINE = {
     Version(1, 0, 0): {
@@ -583,6 +739,8 @@ STIME_LINE = {
         "AnnotationType": (interpret_as_list, format_list, list),
     }
 }
+
+STIME_LINE[Version(1, 1, 0)] = STIME_LINE[Version(1, 0, 0)]
 
 
 class MatchStime(BaseStimeLine):
@@ -801,6 +959,80 @@ class MatchSnote(BaseSnoteLine):
             offset_in_beats=instance.OffsetInBeats,
             score_attributes_list=instance.ScoreAttributesList,
         )
+    
+class MatchVirtualSnote(VirtualSnoteLine):
+    format_fun = dict(
+        Anchor=format_string,
+        AttributesList=format_list,
+    )
+
+    def __init__(
+        self,
+        version: Version,
+        anchor: str,
+        attributes_list: List[str],
+    ) -> None:
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
+        super().__init__(
+            version=version,
+            anchor=anchor,
+            attributes_list=attributes_list,
+        )
+
+    @classmethod
+    def from_matchline(
+        cls,
+        matchline: str,
+        pos: int = 0,
+        version: Version = LATEST_VERSION,
+    ) -> MatchSnote:
+        """
+        Create a new MatchLine object from a string
+
+        Parameters
+        ----------
+        matchline : str
+            String with a matchline
+        pos : int (optional)
+            Position of the matchline in the input string. By default it is
+            assumed that the matchline starts at the beginning of the input
+            string.
+        version : Version (optional)
+            Version of the matchline. By default it is the latest version.
+
+        Returns
+        -------
+        a MatchSnote object
+        """
+
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
+
+        kwargs = cls.prepare_kwargs_from_matchline(
+            matchline=matchline,
+            pos=pos,
+        )
+
+        return cls(version=version, **kwargs)
+
+    @classmethod
+    def from_instance(
+        cls,
+        instance: VirtualSnoteLine,
+        version: Version = LATEST_VERSION,
+    ) -> MatchSnote:
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
+
+        if not isinstance(instance, VirtualSnoteLine):
+            raise ValueError("`instance` needs to be a subclass of `VirtualSnoteLine`")
+
+        return cls(
+            version=version,
+            anchor=instance.Anchor,
+            attributes_list=instance.AttributesList,
+        )
 
 
 NOTE_LINE = {
@@ -932,11 +1164,11 @@ class MatchVirtualPNote(VirtualNoteLine):
     )
 
     out_pattern = (
-        "note({Id},)."
+        "virtualPnote({Id},)."
     )
 
     pattern = re.compile(
-        r"note\((?P<Id>[^,]+),"
+        r"virtualPnote\((?P<Id>[^,]+),"
     )
 
     def __init__(
@@ -1008,7 +1240,6 @@ class MatchVirtualPNote(VirtualNoteLine):
                 track=0,
             )
 
-###############################################################################################################################################
 
 class MatchStimePtime(BaseStimePtimeLine):
     def __init__(
@@ -1108,8 +1339,8 @@ class MatchSnoteVirtualNote(BaseSnoteVirtualNoteLine):
         matchline: str,
         version: Version = LATEST_VERSION,
     ) -> MatchSnoteVirtualNote:
-        if version < Version(1, 0, 0):
-            raise ValueError(f"{version} < Version(1, 0, 0)")
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
 
         kwargs = cls.prepare_kwargs_from_matchline(
             matchline=matchline,
@@ -1124,8 +1355,8 @@ class MatchSnoteVirtualNote(BaseSnoteVirtualNoteLine):
     def from_instance(
         cls, instance: BaseSnoteVirtualNoteLine, version: Version
     ) -> MatchSnoteVirtualNote:
-        if version < Version(1, 0, 0):
-            raise ValueError(f"{version} < Version(1, 0, 0)")
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
 
         if not isinstance(instance, BaseSnoteVirtualNoteLine):
             raise ValueError("`instance` needs to be a subclass of `BaseSnoteVirtualNoteLine`")
@@ -1133,6 +1364,102 @@ class MatchSnoteVirtualNote(BaseSnoteVirtualNoteLine):
         return cls(
             version=version,
             snote=MatchSnote.from_instance(instance.snote, version=version),
+            note=MatchVirtualPNote.from_instance(instance.note, version=version),
+        )
+    
+
+class MatchVirtualSnoteNote(VirtualSnoteNoteLine):
+    def __init__(
+        self,
+        version: Version,
+        snote: VirtualSnoteLine,
+        note: BaseNoteLine,
+    ) -> None:
+        super().__init__(
+            version=version,
+            snote=snote,
+            note=note,
+        )
+
+    @classmethod
+    def from_matchline(
+        cls,
+        matchline: str,
+        version: Version = LATEST_VERSION,
+    ) -> MatchVirtualSnoteNote:
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
+
+        kwargs = cls.prepare_kwargs_from_matchline(
+            matchline=matchline,
+            snote_class=MatchVirtualSnote,
+            note_class=MatchNote,
+            version=version,
+        )
+
+        return cls(**kwargs)
+
+    @classmethod
+    def from_instance(
+        cls, instance: VirtualSnoteNoteLine, version: Version
+    ) -> MatchVirtualSnoteNote:
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
+
+        if not isinstance(instance, VirtualSnoteNoteLine):
+            raise ValueError("`instance` needs to be a subclass of `VirtualSnoteNoteLine`")
+
+        return cls(
+            version=version,
+            snote=MatchVirtualSnote.from_instance(instance.snote, version=version),
+            note=MatchNote.from_instance(instance.note, version=version),
+        )
+
+
+class MatchVirtualSnoteVirtualNote(VirtualSnoteVirtualNoteLine):
+    def __init__(
+        self,
+        version: Version,
+        snote: VirtualSnoteLine,
+        note: VirtualNoteLine,
+    ) -> None:
+        super().__init__(
+            version=version,
+            snote=snote,
+            note=note,
+        )
+
+    @classmethod
+    def from_matchline(
+        cls,
+        matchline: str,
+        version: Version = LATEST_VERSION,
+    ) -> MatchVirtualSnoteVirtualNote:
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
+
+        kwargs = cls.prepare_kwargs_from_matchline(
+            matchline=matchline,
+            snote_class=MatchVirtualSnote,
+            note_class=MatchVirtualPNote,
+            version=version,
+        )
+
+        return cls(**kwargs)
+
+    @classmethod
+    def from_instance(
+        cls, instance: VirtualSnoteVirtualNoteLine, version: Version
+    ) -> MatchVirtualSnoteVirtualNote:
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
+
+        if not isinstance(instance, VirtualSnoteVirtualNoteLine):
+            raise ValueError("`instance` needs to be a subclass of `VirtualSnoteVirtualNoteLine`")
+
+        return cls(
+            version=version,
+            snote=MatchVirtualSnote.from_instance(instance.snote, version=version),
             note=MatchVirtualPNote.from_instance(instance.note, version=version),
         )
 
@@ -1406,6 +1733,7 @@ class MatchSoftPedal(BaseSoftPedalLine):
 
 FROM_MATCHLINE_METHODS = [
     MatchSnoteNote.from_matchline,
+    MatchSnoteVirtualNote.from_matchline,
     MatchSnoteDeletion.from_matchline,
     MatchInsertionNote.from_matchline,
     MatchOrnamentNote.from_matchline,

--- a/partitura/io/matchlines_v1.py
+++ b/partitura/io/matchlines_v1.py
@@ -572,7 +572,7 @@ class MatchSection(MatchLine):
                 "{EndInBeatsOriginal},{RepeatEndType})."
             )
             self.pattern = self.pattern_v1_0_0
-        elif version == Version(1, 1, 0):
+        elif version >= Version(1, 1, 0):
             self.id = id
             self.StartInPerfTime = start_in_perf_time
             self.EndInPerfTime = end_in_perf_time
@@ -601,9 +601,7 @@ class MatchSection(MatchLine):
         class_dict = SECTION_LINE[version]
 
         # Select the appropriate pattern based on version
-        if version == Version(1, 0, 0):
-            pattern = cls.pattern_v1_0_0
-        elif version == Version(1, 1, 0):
+        if version > Version(1, 0, 0):
             pattern = cls.pattern_v1_1_0
         else:
             pattern = cls.pattern_v1_0_0
@@ -973,7 +971,7 @@ class MatchVirtualSnote(VirtualSnoteLine):
         attributes_list: List[str],
     ) -> None:
         if version < Version(1, 1, 0):
-            raise ValueError(f"{version} < Version(1, 1, 0)")
+            raise MatchError(f"Version {version} is not supported by this 1.1.0 parser.")
         super().__init__(
             version=version,
             anchor=anchor,
@@ -1007,7 +1005,7 @@ class MatchVirtualSnote(VirtualSnoteLine):
         """
 
         if version < Version(1, 1, 0):
-            raise ValueError(f"{version} < Version(1, 1, 0)")
+            raise MatchError(f"Version {version} is not supported by this 1.1.0 parser.")
 
         kwargs = cls.prepare_kwargs_from_matchline(
             matchline=matchline,
@@ -1023,7 +1021,7 @@ class MatchVirtualSnote(VirtualSnoteLine):
         version: Version = LATEST_VERSION,
     ) -> MatchSnote:
         if version < Version(1, 1, 0):
-            raise ValueError(f"{version} < Version(1, 1, 0)")
+            raise MatchError(f"Version {version} is not supported by this 1.1.0 parser.")
 
         if not isinstance(instance, VirtualSnoteLine):
             raise ValueError("`instance` needs to be a subclass of `VirtualSnoteLine`")
@@ -1340,7 +1338,7 @@ class MatchSnoteVirtualNote(BaseSnoteVirtualNoteLine):
         version: Version = LATEST_VERSION,
     ) -> MatchSnoteVirtualNote:
         if version < Version(1, 1, 0):
-            raise ValueError(f"{version} < Version(1, 1, 0)")
+            raise MatchError(f"Version {version} is not supported by this 1.1.0 parser.")
 
         kwargs = cls.prepare_kwargs_from_matchline(
             matchline=matchline,
@@ -1356,7 +1354,7 @@ class MatchSnoteVirtualNote(BaseSnoteVirtualNoteLine):
         cls, instance: BaseSnoteVirtualNoteLine, version: Version
     ) -> MatchSnoteVirtualNote:
         if version < Version(1, 1, 0):
-            raise ValueError(f"{version} < Version(1, 1, 0)")
+            raise MatchError(f"Version {version} is not supported by this 1.1.0 parser.")
 
         if not isinstance(instance, BaseSnoteVirtualNoteLine):
             raise ValueError("`instance` needs to be a subclass of `BaseSnoteVirtualNoteLine`")
@@ -1388,7 +1386,7 @@ class MatchVirtualSnoteNote(VirtualSnoteNoteLine):
         version: Version = LATEST_VERSION,
     ) -> MatchVirtualSnoteNote:
         if version < Version(1, 1, 0):
-            raise ValueError(f"{version} < Version(1, 1, 0)")
+            raise MatchError(f"Version {version} is not supported by this 1.1.0 parser.")
 
         kwargs = cls.prepare_kwargs_from_matchline(
             matchline=matchline,
@@ -1404,7 +1402,7 @@ class MatchVirtualSnoteNote(VirtualSnoteNoteLine):
         cls, instance: VirtualSnoteNoteLine, version: Version
     ) -> MatchVirtualSnoteNote:
         if version < Version(1, 1, 0):
-            raise ValueError(f"{version} < Version(1, 1, 0)")
+            raise MatchError(f"Version {version} is not supported by this 1.1.0 parser.")
 
         if not isinstance(instance, VirtualSnoteNoteLine):
             raise ValueError("`instance` needs to be a subclass of `VirtualSnoteNoteLine`")
@@ -1436,7 +1434,7 @@ class MatchVirtualSnoteVirtualNote(VirtualSnoteVirtualNoteLine):
         version: Version = LATEST_VERSION,
     ) -> MatchVirtualSnoteVirtualNote:
         if version < Version(1, 1, 0):
-            raise ValueError(f"{version} < Version(1, 1, 0)")
+            raise MatchError(f"Version {version} is not supported by this 1.1.0 parser.")
 
         kwargs = cls.prepare_kwargs_from_matchline(
             matchline=matchline,
@@ -1452,7 +1450,7 @@ class MatchVirtualSnoteVirtualNote(VirtualSnoteVirtualNoteLine):
         cls, instance: VirtualSnoteVirtualNoteLine, version: Version
     ) -> MatchVirtualSnoteVirtualNote:
         if version < Version(1, 1, 0):
-            raise ValueError(f"{version} < Version(1, 1, 0)")
+            raise MatchError(f"Version {version} is not supported by this 1.1.0 parser.")
 
         if not isinstance(instance, VirtualSnoteVirtualNoteLine):
             raise ValueError("`instance` needs to be a subclass of `VirtualSnoteVirtualNoteLine`")
@@ -1734,6 +1732,8 @@ class MatchSoftPedal(BaseSoftPedalLine):
 FROM_MATCHLINE_METHODS = [
     MatchSnoteNote.from_matchline,
     MatchSnoteVirtualNote.from_matchline,
+    MatchVirtualSnoteNote.from_matchline,
+    MatchVirtualSnoteVirtualNote.from_matchline,
     MatchSnoteDeletion.from_matchline,
     MatchInsertionNote.from_matchline,
     MatchOrnamentNote.from_matchline,
@@ -1875,7 +1875,7 @@ def to_v1(matchline: MatchLine, version: Version = LATEST_VERSION) -> MatchLine:
         return MatchSustainPedal.from_instance(instance=matchline, version=version)
 
     if isinstance(matchline, BaseSoftPedalLine):
-        return MatchSustainPedal.from_instance(instance=matchline, version=version)
+        return MatchSoftPedal.from_instance(instance=matchline, version=version)
 
     else:
         print(matchline.matchline)

--- a/partitura/io/matchlines_v1.py
+++ b/partitura/io/matchlines_v1.py
@@ -71,7 +71,7 @@ from partitura.io.matchfile_utils import (
 
 # Define current version of the match file format
 LATEST_MAJOR_VERSION = 1
-LATEST_MINOR_VERSION = 0
+LATEST_MINOR_VERSION = 1
 LATEST_PATCH_VERSION = 0
 
 LATEST_VERSION = Version(

--- a/partitura/io/matchlines_v1.py
+++ b/partitura/io/matchlines_v1.py
@@ -654,7 +654,7 @@ class MatchOmittedSection(MatchLine):
         "{EndInBeatsOriginal},{SectionAttrList})."
     )
     pattern = re.compile(
-        r"section\("
+        r"omittedSection\("
         r"(?P<id>[^,]+),"
         r"(?P<StartInBeatsUnfolded>[^,]+),"
         r"(?P<EndInBeatsUnfolded>[^,]+),"
@@ -673,11 +673,8 @@ class MatchOmittedSection(MatchLine):
         end_in_beats_original: float,
         section_attr_list: List[str],
     ) -> None:
-        if version not in SECTION_LINE:
-            raise ValueError(
-                f"Unknown version {version}!. "
-                f"Supported versions are {list(SECTION_LINE.keys())}"
-            )
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
         super().__init__(version)
 
         self.field_types = tuple(
@@ -701,11 +698,8 @@ class MatchOmittedSection(MatchLine):
         pos: int = 0,
         version: Version = LATEST_VERSION,
     ) -> MatchSection:
-        if version not in SECTION_LINE:
-            raise ValueError(
-                f"Unknown version {version}!. "
-                f"Supported versions are {list(SECTION_LINE.keys())}"
-            )
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
 
         match_pattern = cls.pattern.search(matchline, pos=pos)
         class_dict = SECTION_LINE[version]
@@ -1155,7 +1149,7 @@ class MatchNote(BaseNoteLine):
                 track=0,
             )
 
-###############################################################################################################################################
+
 class MatchVirtualPNote(VirtualNoteLine):
     field_names = (
         "Id",
@@ -1197,8 +1191,8 @@ class MatchVirtualPNote(VirtualNoteLine):
         pos: int = 0,
         version: Version = LATEST_VERSION,
     ) -> MatchNote:
-        if version < Version(1, 0, 0):
-            raise ValueError(f"{version} < Version(1, 0, 0)")
+        if version < Version(1, 1, 0):
+            raise ValueError(f"{version} < Version(1, 1, 0)")
 
         kwargs = get_kwargs_from_matchline(
             matchline=matchline,

--- a/tests/test_match_export.py
+++ b/tests/test_match_export.py
@@ -13,6 +13,8 @@ from tests import MOZART_VARIATION_FILES
 
 from partitura.io.exportmatch import matchfile_from_alignment, save_match
 from partitura.io.importmatch import load_match
+from partitura.io.matchfile_utils import Version
+from partitura.io.matchlines_v1 import MatchSection, MatchOmittedSection
 from partitura import load_score
 
 
@@ -87,6 +89,23 @@ class TestExportMatch(unittest.TestCase):
 
             perf_from_saved_match, alignment_from_saved_match = load_match(out)
 
+            # Test Metadata
+            # Assuming perf_from_saved_match or the parsed mf holds info
+            # You may need to load the MatchFile object directly to test info lines easily
+            from partitura.io.importmatch import load_matchfile
+            mf = load_matchfile(out)
+            self.assertEqual(mf.info("composer"), "W. A. Mozart")
+            self.assertEqual(mf.info("performer"), "A Pianist")
+            self.assertEqual(mf.info("piece"), "mozart_k265_var1")
+
+            # Test Pedal Data
+            pedals_original = performance[0].controls
+            pedals_saved = perf_from_saved_match[0].controls
+            self.assertEqual(len(pedals_original), len(pedals_saved))
+            for p1, p2 in zip(pedals_original, pedals_saved):
+                self.assertEqual(p1["time"], p2["time"])
+                self.assertEqual(p1["value"], p2["value"])
+
         pna2 = perf_from_saved_match.note_array()
 
         # Test that performance data is the same
@@ -106,3 +125,193 @@ class TestExportMatch(unittest.TestCase):
 
         for al in alignment:
             self.assertTrue(al in alignment_from_saved_match)
+
+    def test_save_match_old_and_new_versions(self):
+        """
+        Test save_match for version 1.0.0 and a newer version with sections.
+        """
+        score_fn = MOZART_VARIATION_FILES["musicxml"]
+        score = load_score(score_fn)
+        match_fn = MOZART_VARIATION_FILES["match"]
+        performance, alignment = load_match(match_fn)
+
+        section = {
+            "id": "section_1",
+            "start_in_beats_unfolded": 0.0,
+            "end_in_beats_unfolded": 1.0,
+            "start_in_beats_original": 0.0,
+            "end_in_beats_original": 1.0,
+            "start_in_perf_time": 0.0,
+            "end_in_perf_time": 1.0,
+            "section_attr_list": ["section_attr"],
+        }
+        omitted_section = {
+            "id": "omitted_1",
+            "start_in_beats_unfolded": 1.0,
+            "end_in_beats_unfolded": 2.0,
+            "start_in_beats_original": 1.0,
+            "end_in_beats_original": 2.0,
+            "section_attr_list": ["omitted_attr"],
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            old_out = os.path.join(tmpdir, "old_version.match")
+            save_match(
+                alignment=alignment,
+                performance_data=performance,
+                score_data=score,
+                out=old_out,
+                version=(1, 0, 0),
+                sections=[section],
+                omitted_sections=[omitted_section],
+            )
+            with open(old_out, "r", encoding="utf-8") as fh:
+                old_content = fh.read()
+
+            self.assertIn("matchFileVersion", old_content)
+            self.assertNotIn("section_1", old_content)
+            self.assertNotIn("omitted_1", old_content)
+
+            new_out = os.path.join(tmpdir, "new_version.match")
+            save_match(
+                alignment=alignment,
+                performance_data=performance,
+                score_data=score,
+                out=new_out,
+                version=(1, 1, 0),
+                sections=[section],
+                omitted_sections=[omitted_section],
+            )
+            with open(new_out, "r", encoding="utf-8") as fh:
+                new_content = fh.read()
+
+            self.assertIn("section_1", new_content)
+            self.assertIn("omitted_1", new_content)
+
+    def test_matchfile_from_alignment_version_specific_lines(self):
+        """
+        Test that version 1.0.0 ignores section lines, while newer versions emit them.
+        """
+        score_fn = MOZART_VARIATION_FILES["musicxml"]
+        score = load_score(score_fn)
+        spart = score[0]
+        match_fn = MOZART_VARIATION_FILES["match"]
+        performance, alignment = load_match(match_fn)
+
+        section = {
+            "id": "section_1",
+            "start_in_beats_unfolded": 0.0,
+            "end_in_beats_unfolded": 1.0,
+            "start_in_beats_original": 0.0,
+            "end_in_beats_original": 1.0,
+            "start_in_perf_time": 0.0,
+            "end_in_perf_time": 1.0,
+            "section_attr_list": ["section_attr"],
+        }
+        omitted_section = {
+            "id": "omitted_1",
+            "start_in_beats_unfolded": 1.0,
+            "end_in_beats_unfolded": 2.0,
+            "start_in_beats_original": 1.0,
+            "end_in_beats_original": 2.0,
+            "section_attr_list": ["omitted_attr"],
+        }
+
+        mf_old = matchfile_from_alignment(
+            alignment=alignment,
+            ppart=performance[0],
+            spart=spart,
+            version=Version(1, 0, 0),
+            sections=[section],
+            omitted_sections=[omitted_section],
+        )
+        self.assertFalse(
+            any(
+                isinstance(line, (MatchSection, MatchOmittedSection))
+                for line in mf_old.lines
+            )
+        )
+
+        mf_new = matchfile_from_alignment(
+            alignment=alignment,
+            ppart=performance[0],
+            spart=spart,
+            version=Version(1, 1, 0),
+            sections=[section],
+            omitted_sections=[omitted_section],
+        )
+        self.assertTrue(any(isinstance(line, MatchSection) for line in mf_new.lines))
+        self.assertTrue(
+            any(isinstance(line, MatchOmittedSection) for line in mf_new.lines)
+        )
+    
+    def test_virtual_notes_export_version_1_1_0(self):
+        """
+        Test the export of virtual notes introduced in version 1.1.0.
+        Virtual notes occur implicitly when the same score_id or performance_id 
+        is aligned multiple times.
+        """
+        from partitura.io.matchlines_v1 import (
+            MatchSnoteNote,
+            MatchVirtualSnoteNote,
+            MatchSnoteVirtualNote,
+            MatchVirtualSnoteVirtualNote
+        )
+        from partitura.io.importmatch import load_matchfile
+
+        score_fn = MOZART_VARIATION_FILES["musicxml"]
+        score = load_score(score_fn)
+        spart = score[0]
+        match_fn = MOZART_VARIATION_FILES["match"]
+        performance, original_alignment = load_match(match_fn)
+        
+        # Extract two distinct valid matches to get authentic IDs
+        matches = [a for a in original_alignment if a["label"] == "match"]
+        m1, m2 = matches[0], matches[1]
+        
+        s1, p1 = m1["score_id"], m1["performance_id"]
+        s2, p2 = m2["score_id"], m2["performance_id"]
+        
+        # Create a synthetic alignment to force the exporter into all 4 states:
+        synthetic_alignment = [
+            # 1. Standard (neither seen before) -> MatchSnoteNote
+            {"label": "match", "score_id": s1, "performance_id": p1}, 
+            
+            # 2. Score ID seen, Perf ID new -> MatchVirtualSnoteNote
+            {"label": "match", "score_id": s1, "performance_id": p2}, 
+            
+            # 3. Score ID new, Perf ID seen -> MatchSnoteVirtualNote
+            {"label": "match", "score_id": s2, "performance_id": p1}, 
+            
+            # 4. Both IDs seen before -> MatchVirtualSnoteVirtualNote
+            {"label": "match", "score_id": s1, "performance_id": p1}, 
+        ]
+        
+        # Export using 1.1.0 logic
+        mf = matchfile_from_alignment(
+            alignment=synthetic_alignment,
+            ppart=performance[0],
+            spart=spart,
+            version=Version(1, 1, 0),
+            assume_part_unfolded=True
+        )
+        
+        # Extract the classes of the generated lines to verify the routing logic worked
+        line_types = [type(line) for line in mf.lines]
+        
+        self.assertIn(MatchSnoteNote, line_types, "Standard MatchSnoteNote missing")
+        self.assertIn(MatchVirtualSnoteNote, line_types, "MatchVirtualSnoteNote missing")
+        self.assertIn(MatchSnoteVirtualNote, line_types, "MatchSnoteVirtualNote missing")
+        self.assertIn(MatchVirtualSnoteVirtualNote, line_types, "MatchVirtualSnoteVirtualNote missing")
+        
+        # Perform a round-trip IO check to ensure the parsers successfully load these lines back
+        with TemporaryDirectory() as tmpdir:
+            out_fn = os.path.join(tmpdir, "virtual_test.match")
+            mf.write(out_fn)
+            
+            parsed_mf = load_matchfile(out_fn)
+            parsed_types = [type(line) for line in parsed_mf.lines]
+            
+            self.assertIn(MatchVirtualSnoteNote, parsed_types, "Failed to parse MatchVirtualSnoteNote")
+            self.assertIn(MatchSnoteVirtualNote, parsed_types, "Failed to parse MatchSnoteVirtualNote")
+            self.assertIn(MatchVirtualSnoteVirtualNote, parsed_types, "Failed to parse MatchVirtualSnoteVirtualNote")

--- a/tests/test_match_import.py
+++ b/tests/test_match_import.py
@@ -451,7 +451,7 @@ class TestMatchLinesV1(unittest.TestCase):
             # assert that the information from the matchline
             # is parsed correctly and results in an identical line
             # to the input match line
-            mo = MatchSectionV1.from_matchline(ml)
+            mo = MatchSectionV1.from_matchline(ml, version=Version(1, 0, 0))
             basic_line_test(mo)
             self.assertTrue(mo.matchline == ml)
 
@@ -1016,6 +1016,52 @@ class TestMatchLinesV1(unittest.TestCase):
             self.assertTrue(False)  # pragma: no cover
         except ValueError:
             self.assertTrue(True)
+    
+    def test_omitted_section_lines_v1_1_0(self):
+        """
+        Test parsing of omitted sections introduced in 1.1.0
+        """
+        from partitura.io.matchlines_v1 import MatchOmittedSection
+        
+        omitted_lines = [
+            "omittedSection(sec1,1.0000,2.0000,1.0000,2.0000,[]).",
+            "omittedSection(sec2,2.0000,4.0000,2.0000,4.0000,[attr1,attr2])."
+        ]
+        
+        for ml in omitted_lines:
+            mo = MatchOmittedSection.from_matchline(ml, version=Version(1, 1, 0))
+            self.assertEqual(mo.matchline, ml)
+            self.assertEqual(mo.version, Version(1, 1, 0))
+            
+        # Should raise an error if parsed with a version older than 1.1.0
+        with self.assertRaises(ValueError):
+            MatchOmittedSection.from_matchline(omitted_lines[0], version=Version(1, 0, 0))
+
+    def test_virtual_note_lines_v1_1_0(self):
+        """
+        Test parsing of virtual notes and their alignments introduced in 1.1.0
+        """
+        from partitura.io.matchlines_v1 import (
+            MatchVirtualPNote,
+            MatchSnoteVirtualNote
+        )
+        
+        # Test MatchVirtualPNote
+        vp_line = "virtualPnote(vpn1,)."
+        vp = MatchVirtualPNote.from_matchline(vp_line, version=Version(1, 1, 0))
+        self.assertEqual(vp.matchline, vp_line)
+        self.assertEqual(vp.Id, "vpn1")
+        
+        # Test MatchSnoteVirtualNote (Standard Snote aligned to a Virtual Pnote)
+        sv_line = "snote(n1,[B,n],3,0:2,1/8,1/8,-0.5000,0.0000,[v1])-virtualPnote(vpn1,)."
+        mo = MatchSnoteVirtualNote.from_matchline(sv_line, version=Version(1, 1, 0))
+        self.assertEqual(mo.matchline, sv_line)
+        self.assertEqual(mo.note.Id, "vpn1")
+        self.assertEqual(mo.snote.Anchor, "n1")
+
+        # Version validation checks
+        with self.assertRaises(ValueError):
+            MatchVirtualPNote.from_matchline(vp_line, version=Version(1, 0, 0))
 
 
 class TestMatchLinesV0(unittest.TestCase):
@@ -1993,6 +2039,50 @@ class TestMatchUtils(unittest.TestCase):
             for component in ks.other_components:
                 key_name = fifths_mode_to_key_name(component.fifths, component.mode)
                 self.assertTrue(str(component).startswith(key_name))
+
+    def test_validate_match_ids_removes_duplicates(self):
+        """
+        Test that validate_match_ids successfully catches duplicate insertions
+        and deletions, issues warnings, and removes the corrupted lines.
+        """
+        import warnings
+        from partitura.io.importmatch import validate_match_ids
+        from partitura.io.matchfile_base import MatchFile
+        from partitura.io.matchlines_v1 import MatchSnoteDeletion, MatchInsertionNote, MatchSnote, MatchNote
+
+        v = Version(1, 0, 0)
+        
+        # Create a mock Score Note and Performance Note
+        sn1 = MatchSnote(v, "n1", "C", 0, 4, 1, 1, FractionalSymbolicDuration(0), FractionalSymbolicDuration(1), 0.0, 1.0, [])
+        pn1 = MatchNote(v, "p1", 60, 0, 100, 64, 1, 0)
+        
+        # Create DUPLICATE deletions (same score Anchor)
+        del1 = MatchSnoteDeletion(v, sn1)
+        del2 = MatchSnoteDeletion(v, sn1) 
+
+        # Create DUPLICATE insertions (same performance Id)
+        ins1 = MatchInsertionNote(v, pn1)
+        ins2 = MatchInsertionNote(v, pn1) 
+
+        # Build MatchFile
+        mf = MatchFile(lines=[del1, del2, ins1, ins2])
+        
+        # Ensure we have 4 lines before validation
+        self.assertEqual(len(mf.lines), 4)
+        
+        # Catch the warnings that validate_match_ids is supposed to emit
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            
+            validate_match_ids(mf)
+            
+            # It should have fired exactly two warnings (one for insertions, one for deletions)
+            self.assertEqual(len(w), 2)
+            self.assertTrue("duplicate score notes" in str(w[0].message))
+            self.assertTrue("duplicate performance notes" in str(w[1].message))
+            
+        # The function removes ALL instances of the duplicates, so lines should be 0
+        self.assertEqual(len(mf.lines), 0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds support for flexible, non-unique note alignments (as per Chiruthapudi et al., 2026) and fixes a bug with measure numbering during export.

**What’s new:**

- Virtual Pointer Notes: Added virtualSnote and virtualPnote to handle N-to-M mappings, essential for rehearsals and basso continuo realizations.

- Extended Sections: Added section and omittedSection lines for better handling of repeats and practice segments.

- Alignment Sorting: Added the _sort_alignment_ parameter to flexibly sort alignments chronologically by performance time (ptime), score time (stime), or disable sorting to preserve the original algorithm's order (False/None).

- Bug Fix (Bug: Incorrect measure numbers in matchfile export for repeated segments #506): Fixed an issue where repeated score segments resulted in incorrect measure numbers in exported match files.

**Compatibility:**
Everything should be fully backward-compatible. Version(1,0,0) match files are still supported, and new features only trigger when using the new Version(1,1,0).

_Note on create_score from match files:_
Currently, load_match(..., create_score=True) does not account for omittedSection lines. This should be done in a follow-up PR by ensuring empty bars or rests are correctly inserted to keep measure numbering consistent.