### PR TITLE
Fix seconds_to_midi_ticks crash on numpy array input (removed np.int alias)

### DIFF
--- a/partitura/utils/music.py
+++ b/partitura/utils/music.py
@@ -489,7 +489,7 @@ def seconds_to_midi_ticks(
     midi_ticks = np.round(1e6 * ppq * time_in_seconds / mpq)
 
     if isinstance(time_in_seconds, np.ndarray):
-        return midi_ticks.astype(np.int)
+        return midi_ticks.astype(int)
     else:
         return int(midi_ticks)
 

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -3,7 +3,11 @@ This module contains tests for testing conversions from beats and quarters.
 """
 
 import unittest
+
+import numpy as np
+
 import partitura.score as score
+from partitura.utils.music import seconds_to_midi_ticks, midi_ticks_to_seconds
 
 
 def _test_time_pairs(part, time_pairs):
@@ -55,3 +59,50 @@ class TestBeatVsQuarterTimes(unittest.TestCase):
 
         time_pairs = [(-3, -1.5), (0, 0), (6, 3)]
         _test_time_pairs(part, time_pairs)
+
+
+class TestSecondsToMidiTicks(unittest.TestCase):
+    """
+    Test seconds_to_midi_ticks with numpy array input -- the documented path
+    that previously crashed because it used the removed np.int alias.
+    """
+
+    def test_array_input_returns_int_array(self):
+        # The docstring promises an int-dtype array for array input; this is
+        # the line that raised AttributeError on numpy >= 1.24.
+        seconds = np.array([0.0, 0.5, 1.0, 2.0])
+        ticks = seconds_to_midi_ticks(seconds)
+        self.assertIsInstance(ticks, np.ndarray)
+        self.assertTrue(np.issubdtype(ticks.dtype, np.integer))
+        self.assertTrue(np.array_equal(ticks, np.array([0, 480, 960, 1920])))
+
+    def test_array_matches_scalar(self):
+        seconds = np.array([0.0, 0.25, 0.5, 1.0, 1.5, 2.0])
+        ticks = seconds_to_midi_ticks(seconds)
+        scalar_ticks = np.array([seconds_to_midi_ticks(float(s)) for s in seconds])
+        self.assertTrue(np.array_equal(ticks, scalar_ticks))
+
+    def test_array_roundtrip(self):
+        seconds = np.array([0.0, 0.5, 1.0, 2.0])
+        recovered = midi_ticks_to_seconds(seconds_to_midi_ticks(seconds))
+        self.assertTrue(np.allclose(recovered, seconds))
+
+    def test_array_non_default_mpq_ppq(self):
+        seconds = np.array([0.0, 1.0, 2.0])
+        ticks = seconds_to_midi_ticks(seconds, mpq=600000, ppq=960)
+        scalar_ticks = np.array(
+            [seconds_to_midi_ticks(float(s), mpq=600000, ppq=960) for s in seconds]
+        )
+        self.assertTrue(np.issubdtype(ticks.dtype, np.integer))
+        self.assertTrue(np.array_equal(ticks, scalar_ticks))
+
+    def test_empty_array(self):
+        ticks = seconds_to_midi_ticks(np.array([]))
+        self.assertIsInstance(ticks, np.ndarray)
+        self.assertTrue(np.issubdtype(ticks.dtype, np.integer))
+        self.assertEqual(len(ticks), 0)
+
+    def test_scalar_still_returns_python_int(self):
+        ticks = seconds_to_midi_ticks(1.0)
+        self.assertIsInstance(ticks, int)
+        self.assertEqual(ticks, 960)


### PR DESCRIPTION
### The bug

`seconds_to_midi_ticks` documents `np.ndarray` input and an int-dtype array output, but that documented path crashes on any modern numpy:

```python
import numpy as np
from partitura.utils.music import seconds_to_midi_ticks

seconds_to_midi_ticks(1.0)                      # 960            (scalar path OK)
seconds_to_midi_ticks(np.array([0., 1., 2.]))   # AttributeError: module 'numpy' has no attribute 'int'
```

The docstring is explicit: *"If the output was a numpy array, the output will be a numpy array with dtype int."* The scalar path works and the inverse `midi_ticks_to_seconds` handles arrays fine, so only this one path is broken.

### Root cause

`partitura/utils/music.py`, in `seconds_to_midi_ticks`:

```python
if isinstance(time_in_seconds, np.ndarray):
    return midi_ticks.astype(np.int)     # np.int removed in numpy 1.24+
else:
    return int(midi_ticks)
```

`np.int` was a deprecated alias for the builtin `int`, removed in numpy 1.24; accessing it now raises `AttributeError`. Every internal caller (`performance.py`, `exportmatch.py`, the controls code in `music.py`) passes a scalar and hits the `else` branch, so the array branch was never covered by the test suite and the regression went unnoticed. This is the **last surviving** `np.int`/`np.float` in the codebase — closed issue #27 ("Update dtypes") purged the rest in 2021 but missed this line.

### The fix

Use the builtin `int` (numpy's own message prescribes exactly this, with no behaviour change):

```python
return midi_ticks.astype(int)
```

The array path now returns `array([0, 480, 960, 1920])` with integer dtype, matching the scalar path element-for-element.

### Tests

A new `TestSecondsToMidiTicks` in `tests/test_times.py` covers the array path that previously crashed: int-dtype output, element-wise agreement with the scalar path, the float round-trip through `midi_ticks_to_seconds`, non-default `mpq`/`ppq`, an empty array, and a guard that scalar input still returns a builtin `int`. Five of the six fail on `develop` (the array cases raise) and all pass with the fix; the existing `test_times`, midi import/export, and performance suites stay green.
