### PR TITLE
Return an empty spelling for an empty note array

### DIFF
--- a/partitura/musicanalysis/pitch_spelling.py
+++ b/partitura/musicanalysis/pitch_spelling.py
@@ -63,11 +63,17 @@ def estimate_spelling(note_info, method="ps13s1", **kwargs):
     """
     if method == "ps13s1":
         ps = ps13s1
-    step, alter, octave = ps(ensure_notearray(note_info), **kwargs)
+    note_array = ensure_notearray(note_info)
 
     spelling = np.empty(
-        len(step), dtype=[("step", "U1"), ("alter", int), ("octave", int)]
+        len(note_array), dtype=[("step", "U1"), ("alter", int), ("octave", int)]
     )
+
+    if len(note_array) == 0:
+        # No notes to spell (e.g. a MIDI file without note events).
+        return spelling
+
+    step, alter, octave = ps(note_array, **kwargs)
 
     spelling["step"] = step
     spelling["alter"] = alter

--- a/tests/test_pitch_spelling.py
+++ b/tests/test_pitch_spelling.py
@@ -39,3 +39,13 @@ class TestKeyEstimation(unittest.TestCase):
         spelling = estimate_spelling(self.score[0].note_array())
         comparisons = compare_spelling(spelling, self.score[0].notes)
         self.assertTrue(np.all(comparisons), "Incorrect spelling")
+
+    def test_empty_note_array(self):
+        # An empty note array (e.g. a MIDI file without note events) used to
+        # raise IndexError instead of returning an empty spelling.
+        empty = np.array(
+            [], dtype=[("onset_div", int), ("pitch", int), ("duration_div", int)]
+        )
+        spelling = estimate_spelling(empty)
+        self.assertEqual(len(spelling), 0)
+        self.assertEqual(spelling.dtype.names, ("step", "alter", "octave"))


### PR DESCRIPTION
`estimate_spelling` raises `IndexError` when it gets a note array with no notes, because `compute_morph_array` immediately reads `chroma_array[0]`. I ran into this loading a MIDI file that only has tempo/meta events and no notes. `estimate_key` already returns cleanly on the same empty input, so this makes spelling behave the same way and returns an empty spelling array.