### PR TITLE
Do not crash on a chord note that follows a rest

### DIFF
--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -1371,14 +1371,14 @@ def _handle_note(e, position, part, ongoing, prev_note, doc_order, prev_beam=Non
     if chord is not None:
         # this note starts at the same position as the previous note, and has
         # same duration
-        if not isinstance(prev_note, score.Note):
-            # Malformed MusicXML: a <chord> child with no note to anchor to,
-            # either the first note of a part (or first after a backup/forward),
-            # where prev_note is None, or one that follows a <rest>, where
-            # prev_note is a Rest and has no timing or is_grace_chord to copy.
-            # Warn and continue, treating this note as a standalone, which is
-            # better than the bare AttributeError this used to raise on a rest
-            # and crashed the whole load.
+        if not isinstance(prev_note, (score.Note, score.UnpitchedNote)):
+            # Malformed MusicXML: a <chord> child with no pitched or unpitched
+            # note to anchor to, either the first note of a part (or first after
+            # a backup/forward), where prev_note is None, or one that follows a
+            # <rest>, where prev_note is a Rest with no timing to copy. Warn and
+            # continue, treating this note as a standalone, which is better than
+            # the bare AttributeError this used to raise on a rest and crashed
+            # the whole load.
             warnings.warn(
                 "Found <chord> on a note with no preceding note to anchor to "
                 "(malformed MusicXML); treating as a standalone note.",
@@ -1386,7 +1386,9 @@ def _handle_note(e, position, part, ongoing, prev_note, doc_order, prev_beam=Non
             )
         else:
             is_grace_chord = True
-            if prev_note.is_grace_chord == False:
+            # UnpitchedNote (percussion) can also be wrapped by <chord> tags but
+            # has no is_grace_chord attribute, so read it defensively.
+            if getattr(prev_note, "is_grace_chord", False) == False:
                 prev_note.is_grace_chord = True
             position = prev_note.start.t
             duration = prev_note.duration

--- a/partitura/io/importmusicxml.py
+++ b/partitura/io/importmusicxml.py
@@ -1371,15 +1371,17 @@ def _handle_note(e, position, part, ongoing, prev_note, doc_order, prev_beam=Non
     if chord is not None:
         # this note starts at the same position as the previous note, and has
         # same duration
-        if prev_note is None:
-            # Malformed MusicXML: a <chord> child on the first note of a part
-            # (or first after a backup/forward) leaves us with no anchor to
-            # copy timing from. Warn and continue, treating this note as a
-            # standalone — better than the bare AssertionError this used to
-            # raise, which crashed the whole load.
+        if not isinstance(prev_note, score.Note):
+            # Malformed MusicXML: a <chord> child with no note to anchor to,
+            # either the first note of a part (or first after a backup/forward),
+            # where prev_note is None, or one that follows a <rest>, where
+            # prev_note is a Rest and has no timing or is_grace_chord to copy.
+            # Warn and continue, treating this note as a standalone, which is
+            # better than the bare AttributeError this used to raise on a rest
+            # and crashed the whole load.
             warnings.warn(
-                "Found <chord> on a note with no preceding note (malformed "
-                "MusicXML); treating as a standalone note.",
+                "Found <chord> on a note with no preceding note to anchor to "
+                "(malformed MusicXML); treating as a standalone note.",
                 stacklevel=2,
             )
         else:

--- a/tests/test_export_robustness.py
+++ b/tests/test_export_robustness.py
@@ -121,6 +121,35 @@ _CHORD_AFTER_REST_XML = """\
 """
 
 
+_UNPITCHED_CHORD_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P1"><part-name>Drums</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>4</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note>
+        <unpitched><display-step>E</display-step><display-octave>4</display-octave></unpitched>
+        <duration>4</duration>
+        <type>quarter</type>
+      </note>
+      <note>
+        <chord/>
+        <unpitched><display-step>G</display-step><display-octave>4</display-octave></unpitched>
+        <duration>4</duration>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>
+"""
+
+
 class TestMusicXMLImportRobustness(unittest.TestCase):
     def test_chord_on_first_note_warns_and_continues(self):
         with tempfile.TemporaryDirectory() as td:
@@ -152,5 +181,25 @@ class TestMusicXMLImportRobustness(unittest.TestCase):
             self.assertTrue(
                 any("chord" in str(item.message).lower() for item in w),
                 f"expected a chord-without-prev warning, got {[str(i.message) for i in w]}",
+            )
+
+    def test_unpitched_chord_anchors_to_prev(self):
+        # Unpitched (percussion) notes can also be wrapped by <chord> tags. The
+        # second note here should anchor to the first rather than being warned
+        # about and dropped to a standalone.
+        with tempfile.TemporaryDirectory() as td:
+            xml_path = Path(td) / "unpitched_chord.musicxml"
+            xml_path.write_text(_UNPITCHED_CHORD_XML)
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                s = pt.load_musicxml(str(xml_path))
+            self.assertEqual(len(s), 1)
+            notes = list(s[0].iter_all(score.UnpitchedNote))
+            self.assertEqual(len(notes), 2)
+            # both notes share the same onset, i.e. they form a chord
+            self.assertEqual(notes[0].start.t, notes[1].start.t)
+            self.assertFalse(
+                any("no preceding note" in str(item.message) for item in w),
+                f"unpitched chord should not warn, got {[str(i.message) for i in w]}",
             )
 

--- a/tests/test_export_robustness.py
+++ b/tests/test_export_robustness.py
@@ -92,6 +92,35 @@ class TestMidiExportRobustness(unittest.TestCase):
             )
 
 
+_CHORD_AFTER_REST_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P1"><part-name>P</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>4</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+      </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <type>quarter</type>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>
+"""
+
+
 class TestMusicXMLImportRobustness(unittest.TestCase):
     def test_chord_on_first_note_warns_and_continues(self):
         with tempfile.TemporaryDirectory() as td:
@@ -104,6 +133,22 @@ class TestMusicXMLImportRobustness(unittest.TestCase):
             na = s[0].note_array()
             self.assertEqual(len(na), 2)
             # ensure we surfaced a warning (rather than the old bare assert)
+            self.assertTrue(
+                any("chord" in str(item.message).lower() for item in w),
+                f"expected a chord-without-prev warning, got {[str(i.message) for i in w]}",
+            )
+
+    def test_chord_after_rest_warns_and_continues(self):
+        with tempfile.TemporaryDirectory() as td:
+            xml_path = Path(td) / "chord_after_rest.musicxml"
+            xml_path.write_text(_CHORD_AFTER_REST_XML)
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                s = pt.load_musicxml(str(xml_path))
+            self.assertEqual(len(s), 1)
+            na = s[0].note_array()
+            # the rest carries no pitch; the chord note is kept as a standalone
+            self.assertEqual(len(na), 1)
             self.assertTrue(
                 any("chord" in str(item.message).lower() for item in w),
                 f"expected a chord-without-prev warning, got {[str(i.message) for i in w]}",


### PR DESCRIPTION
When a `<note>` with a `<chord/>` follows a `<rest>`, `_handle_note` reads `prev_note.is_grace_chord`, but `prev_note` is a `Rest` and only `Note` carries that attribute, so the whole load dies with `AttributeError`. The existing code already treats a `<chord/>` with no preceding note (prev_note is None) as malformed and continues with a warning, so I widened that same guard to cover a rest as well. Added a robustness test next to the first-note one.